### PR TITLE
Det-rule error

### DIFF
--- a/data/relex2logic-rules.txt
+++ b/data/relex2logic-rules.txt
@@ -12,7 +12,7 @@
 
 [TENSEPOS] {5} <> tense($W, $Tense) & pos($W, verb) => (tense-rule $W (get-instance-name $W word_index sentence_index) $Tense)
 
-[DET] {6} <> _det($W, $x) => (det-rule $W (get-instance-name $W word_index sentence_index) choose_var_name $x)
+[DET] {6} <> _det($W, $x) => (det-rule $W (get-instance-name $W word_index sentence_index) choose-var-name $x)
 
 [NEGFLAG] {7} <> NEGATIVE-FLAG($V, T) => (negative-rule $V (get-instance-name $V word_index sentence_index))
 


### PR DESCRIPTION
The det-rule didn't work properly. First bug was that the relex2logic-rules.txt file called the method `choose_var_name` which was named `choose-var-name` in relex-to-logic.scm.
There's another error now saying that choose-var-name is returning an argument of the wrong type (?).

```
37: 4 [lp (det-rule "man" # choose-var-name ...)]
In ice-9/eval.scm:
 368: 3 [eval # #]
In unknown file:
   ?: 2 [cog-new-node VariableNode {#<procedure choose-var-name ()>}]
In ice-9/boot-9.scm:
 102: 1 [#<procedure a75bee0 at ice-9/boot-9.scm:97:6 (thrown-k . args)> wrong-type-arg ...]
In unknown file:
   ?: 0 [catch-closure wrong-type-arg "cog-new-node" ...]

ERROR: In procedure catch-closure:
ERROR: In procedure cog-new-node: Wrong type argument in position 2 (expecting string name for the node): #<procedure choose-var-name ()>
ABORT: wrong-type-arg
```

I've had a look at the functions, but couldn't find the error yet as `random-string` which is called by `choose-var-name` is returning a string. Maybe you can help, @amebel?
