### PR TITLE
Allow rules to be applied multiple times

### DIFF
--- a/src/java/relex/output/LogicProcessor.java
+++ b/src/java/relex/output/LogicProcessor.java
@@ -157,12 +157,8 @@ public class LogicProcessor
 
 			List<String> appliedRules = new ArrayList<String>();
 
-			System.out.println("   Start check all rules on this node " + startNode.get("name"));
-
 			for (Rule thisRule: clonedRulesSet)
 			{
-				System.out.println("  Checking rule " + thisRule.getName());
-
 				Boolean bNotMutuallyExclusive = true;
 
 				for (String appliedRule : appliedRules)
@@ -197,16 +193,6 @@ public class LogicProcessor
 
 					if (ruleResult.passed)
 					{
-						System.out.println("Rule " + tempRule.getName() + " passed at node " + startNode.get("name"));
-
-						for (String key : ruleResult.valuesMap.keySet())
-						{
-							String value = ruleResult.valuesMap.get(key);
-							String uuid = ruleResult.uuidsMap.get(key);
-
-							System.out.println(" " + key + ", " + value + ", " + uuid);
-						}
-
 						// actually write the matched values into the rule
 						for (Criterium thisCriterium : tempRule.getCriteria())
 						{
@@ -221,8 +207,6 @@ public class LogicProcessor
 
 						if (tempRule.getAllCriteriaSatisfied())
 						{
-							System.out.println(tempRule.getName() + " satisfied.");
-
 							if (tempRule.getName().compareTo("MAYBE") != 0 || ruleResult.maybeCheck)
 							{
 								Boolean applied = false;
@@ -359,8 +343,6 @@ public class LogicProcessor
 				return;
 			}
 
-			System.out.println("  " + foundCriteriums.size() + " criteriums matched");
-
 			// criteriums matched, remove them all for the next level
 			criteriums.removeAll(foundCriteriums);
 
@@ -378,22 +360,15 @@ public class LogicProcessor
 			List<List<ChildParentPair>> allComb = new ArrayList<List<ChildParentPair>>();
 			generateAllComb(foundPairs, 0, allComb, new Stack<ChildParentPair>());
 
-			System.out.println("    " + allComb.size() + " combinations found");
-
 			// for each combination, search deeper for more criteriums
 			for (List<ChildParentPair> pairs : allComb)
 			{
-				System.out.println("       Size of this combination is " + pairs.size());
-
 				for (ChildParentPair pair : pairs)
 					matchedPairs.push(pair);
 
 				// pick one node and search deeper, and do this for all nodes in this combination
 				for (ChildParentPair pair : pairs)
-				{
-					System.out.println("          going deeper");
 					recursiveMatchAndApply(rule, pair.child, visitedNodes, criteriums, matchedPairs, results);
-				}
 
 				for (int i = 0; i < pairs.size(); i++)
 					matchedPairs.pop();


### PR DESCRIPTION
This is turning out more complex than I think is necessary.  Perhaps a more elegant solution is possible?  What I thought would be a basic switching the order of a loop turns out to be more.  Basically, I spent most time solving structure such as this one:

```
[word1 [links [rel1 [member0 word2 [links [rel5 ...
                    [member1 ...
                    ....
              [rel2 [member0 ...
                    ....
              [rel3 [member0 ...
                    ....
              [rel4 wordN [links ...
```

If we have two rules:

```
rule1: (rel1($a, $b) & rel2($a, $c) & rel3($a, $d) & rel4($a, $e)
rule2: (rel1($a, $b) & rel2($a, $c) & rel3($a, $d) & rel4($a, $e) & rel5($b, $f)
```

Then for rule1, we need to generate all possible combination of links/member# of rel1 to rel4, since a rule can be applied multiple times.  In addition, for rule2, in addition to generating all combination, we also need to check deeper into all the path to check if one or more of them link to a rel5.  Additional care also needed to avoid loop.  The solution I have implemented now involves a lot of recursions... and I can in fact still think of one extreme case which my code might not cover.

Perhaps working directly with the Feature Structure is not the best solution for Relex2Logic?  I think this because Feature Structure treat a word node as parent to relation, but R2L works with relation first before checking the word.  It might be easier to crawl the structure once and generate a list of triplets:

```
<relation_name <word1, word1uuid> <word2, word2uuid>>
```

But then it will still be a problem of finding all possible combinations.
