### PR TITLE
Dollar sign matcher fix + New method for regular expression check

### DIFF
--- a/src/java/relex/logic/Rule.java
+++ b/src/java/relex/logic/Rule.java
@@ -195,7 +195,7 @@ public class Rule {
 	 * @param otherName   The rule name to check
 	 * @return            True if excluded, false otherwise
 	 */
-	public Boolean isRuleMutuallyExlusive(String otherName)
+	public Boolean isRuleMutuallyExclusive(String otherName)
 	{
 		for (String ruleRegex : _exclusionList)
 		{


### PR DESCRIPTION
Fixes replaceAll crashing when we are replacing a variable with _$qVar (from sentences such as "Where did you go today?")
