### PR TITLE
NI1_Time: fix for ND connector

### DIFF
--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -1759,13 +1759,69 @@ NUMBER-NUMERIC-QUANTIFIERS
 =
 <F_R ref links _num_quantity> = <F_L ref>
 <F_L IS-NUMBER-FLAG> = T
+;
+;Different uses of the NI connectors are handled separately. 
+;
+;NUMBER-1a handles "15 kDa to 20 kDa" and "15 kDa"
+;
 #TemplateActionAlg
 NUMBER-1a
-<LAB> = \ND\.*|\NI\.*
+;<LAB> = \ND\.*|\NI\.*
+<LAB> = \ND\.*
 <F_L QUANTITY-EXCEPTION-FLAG> != T
 =
 <F_R ref links _quantity> = <F_L ref>
 <F_L IS-NUMBER-FLAG> = T
+<F_R NOT_NUMBER_FLAG> = T
+;
+;The three algorithmhs below handle "15 to 20 kDa"
+;
+#TemplateActionAlg
+NUMERICAL_RANGES_L
+<LAB> = \NIf\.*
+<F_L NOT_NUMBER_FLAG> = %
+=
+<F_R numerical_ranges> += <F_L>
+;
+#TemplateActionAlg
+NUMERICAL_RANGES_R
+<LAB> = \NIt\.*
+<F_R NOT_NUMBER_FLAG> = %
+=
+<F_L numerical_ranges> += <F_R>
+;
+#TemplateActionAlg
+NUMBER-NUMERICAL_RANGES
+<F_R ref links _quantity> != %
+<F_L numerical_ranges> != %
+<F_L numerical_ranges member0 QUANTITY-EXCEPTION-FLAG> != T
+<F_L numerical_ranges member1 QUANTITY-EXCEPTION-FLAG> != T
+=
+<F_R ref links _quantity> = %
+<F_R ref links _quantity> = <F_L numerical_ranges member0 ref>
+<F_R ref links _quantity> += <F_L numerical_ranges member1 ref>
+<F_L numerical_ranges member0 IS-NUMBER-FLAG> = T
+<F_L numerical_ranges member1 IS-NUMBER-FLAG> = T
+;
+;Handles all other cases of NI connectors
+;
+#TemplateActionAlg
+NUMBER-1c
+<LAB> = \NI\.*
+<LAB> != \NIf\.*
+<LAB> != \NIt\.*
+<LAB> != \NIr\.*
+<F_L QUANTITY-EXCEPTION-FLAG> != T
+=
+<F_R ref links _quantity> = <F_L ref>
+<F_L IS-NUMBER-FLAG> = T
+;
+#TemplateActionAlg
+TIME
+<F_R ref name> = AM|PM|am|pm|a.m.|p.m.
+=
+<F_R ref links _time> = <F_R ref links _quantity>
+<F_R ref links _quantity> = %
 ;
 #TemplateActionAlg
 NUMBER-2


### PR DESCRIPTION
The different NI connectors are not handled by relex at all. It seems best to handle each NI connector such as Nif/NIt and NI*p separately.

More specifically, this fix handles 

“Jane is at the daycare center every day of the week between 7 am and 7:30 am and between 16 pm and 16:30 pm.” which relex outputs previously as 

_pobj(at, center)
_psubj(at, Jane)
_quantity(and, 7am)
_quantity(7:30am, and)

Now becomes

_pobj(at, center)
    _psubj(at, Jane)
    conj_and(between, between)
    _time(pm, 16)
    _time(pm, 16:30)
    _time(am, 7)
    _time(am, 7:30)

Expressions which require numerical modifiers such as pm, m (meters), etc need to be written with space. So, 7am won't work but 7 am does. This looks like a link-grammar issue.

The use of a time flag is deemed redundant and “_time” seems to suffice for the identification of time information.

More generally, the fix handles the use of the NI connectors with the ND connector.

Fixes for other NI connector types and their use with other types of connectors such as Dmcn are yet to be implemented.
