### PR TITLE
Conjunction

### DIFF
--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -33,6 +33,7 @@ CONJ_AND_L
 <LAB> = \AJl\.*|\MJl\.*|\QJl\.*|\RJl\.*|\SJl\.*|\VJl\.*
 =
 <F_R conj> += <F_L>
+;for sentences with many conjunctions
 ;Example- "I need to find a hong kong engineer , who knows Java and python and
 ; worked at Oracle and went to stanford and is a VP."
 #TemplateActionAlg


### PR DESCRIPTION
Fix for sentence with many "and"
Example : "I need to find a hong kong engineer , who knows Java and python and worked at Oracle and went to stanford and is a VP."
correct output :
   _to-do(need, find)
    _subj(need, I)
    _amod(engineer, kong)
    _obj(know, Java)
    _obj(know, python)
    conj_and(know, work)
    _subj(know, _$qVar)
    to(go, stanford)
    conj_and(go, be)
    _det(VP, a)
    _obj(be, VP)
    conj_and(work, go)
    at(work, Oracle)
    conj_and(Java, python)
    _iobj(find, hong)
    _obj(find, engineer)
