### PR TITLE
Fixes R2L exclusion failure

### DIFF
--- a/src/java/relex/output/LogicProcessor.java
+++ b/src/java/relex/output/LogicProcessor.java
@@ -139,6 +139,10 @@ public class LogicProcessor
 			if (!attrName.equals("nameSource"))
 				return false;
 
+			// skip binary relations as that is already processed
+			if (srcNode.get("links") != null)
+				return false;
+
 			applyRules(srcNode);
 
 			return false;


### PR DESCRIPTION
Fixes for the sentence "The book which I read was damaged."  The unique Feature Structure happened to cause both SV and SVO rule to be applied due to the way it is traversed.

```
[background $0[links [_obj $7[definite-FLAG <<T>>
                              links [which $0]
                              name $46<<book>>
                              noun_number $48<<singular>>
                              pos $49<<noun>>
                              subscript-TAG $50<<.n>>]
                      _subj $30[definite-FLAG <<T>>
                                gender $32<<person>>
                                name $35<<I>>
                                noun_number $34<<singular>>
                                pos $31<<noun>>
                                pronoun-FLAG <<T>>
                                subscript-TAG $36<<.p>>]]
               name $51<<read>>
               pos $52<<verb>>
               subscript-TAG $53<<.v-d>>
               tense $54<<past>>]
 head $17[links [_obj $7]
          name $19<<damage>>
          pos $15<<verb>>
          subscript-TAG $20<<.v-d>>
          tense $21<<past_passive>>]]
```
