### PR TITLE
SIG in links fix

### DIFF
--- a/src/java/relex/output/LogicProcessor.java
+++ b/src/java/relex/output/LogicProcessor.java
@@ -321,6 +321,11 @@ public class LogicProcessor
 						for (String linkToName : linksNode.getFeatureNames())
 						{
 							FeatureNode subNode = linksNode.get(linkToName);
+
+							// to handle valued node like SIG in links (which appears for that-clause)
+							if (subNode.isValued())
+								continue;
+
 							FeatureNode memberNode = subNode.get("member0");
 
 							if (memberNode != null)


### PR DESCRIPTION
Sometimes "links" node can connect to a valued node, like SIG, which appears for sentence "It is our hope that he will do it."  Added a special check for it.
