### PR TITLE
that-rule preprocessing proposal

### DIFF
--- a/data/relex2logic-rules.txt
+++ b/data/relex2logic-rules.txt
@@ -73,5 +73,6 @@
 [THAT-EXCL-2] {100} <> that($A, $B) & pos($B, noun) => ; ignoring adjective clause between $A and $B 
 
 # general that-rule works for any pos
-[THAT] {110} <THAT-EXCL-1, THAT-EXCL-2> that($A, $B) & pos($A, $A_POS) & pos($B, $B_POS) => (that-rule $A (get-instance-name $A word_index sentence_index) $A_POS $B (get-instance-name $B word_index sentence_index) $B_POS)
+[THAT1] {110} <THAT-EXCL-1, THAT-EXCL-2> that($A, $B) & pos($A, $A_POS) & pos($B, $B_POS) => (that-rule $A (get-instance-name $A word_index sentence_index) $A_POS $B (get-instance-name $B word_index sentence_index) $B_POS)
+[THAT2] {110} <THAT-EXCL-1, THAT-EXCL-2> _that($A, $B) & pos($A, $A_POS) & pos($B, $B_POS) => (that-rule $A (get-instance-name $A word_index sentence_index) $A_POS $B (get-instance-name $B word_index sentence_index) $B_POS)
 


### PR DESCRIPTION
This is assuming that "that_adj" and maybe "_that" will go away (discussed on #96).  Otherwise, if "that_adj" stays, that THAT-EXCL-1 and THAT-EXCL-2 is not needed.  If "_that" stays, we will need a separate rule for it.

Targeted at "object clause", "content clause", "complement clause", etc, etc, but not "adjective clause".  [Is there a general name for these??]
