### PR TITLE
Makes the that-excl rules work with SuReal's r2l function

### DIFF
--- a/data/relex2logic-rules.txt
+++ b/data/relex2logic-rules.txt
@@ -110,8 +110,8 @@
 # that rules for object clause, content clause, complement clause, etc, but not adjective clause
 # ============================================
 # skipping adjective clause
-[THAT-EXCL-1] {100} <> that($A, $B) & pos($A, noun) => ; ignoring adjective clause between $A and $B 
-[THAT-EXCL-2] {100} <> that($A, $B) & pos($B, noun) => ; ignoring adjective clause between $A and $B 
+[THAT-EXCL-1] {100} <> that($A, $B) & pos($A, noun) => '() ; ignoring adjective clause between $A and $B 
+[THAT-EXCL-2] {100} <> that($A, $B) & pos($B, noun) => '() ; ignoring adjective clause between $A and $B 
 
 # general that-rule works for any pos
 [THAT1] {110} <THAT-EXCL-1, THAT-EXCL-2> that($A, $B) & pos($A, $A_POS) & pos($B, $B_POS) => (that-rule $A (get-instance-name $A word_index sentence_index) $A_POS $B (get-instance-name $B word_index sentence_index) $B_POS)


### PR DESCRIPTION
The comment causes `eval-string` to return `#<unspecified>` which then crashes SuReal's `set-link` since you cannot `cog-new-link` `#<unspecified>`
