### PR TITLE
removed unneeded retrieval of head node

### DIFF
--- a/src/java/relex/output/LogicView.java
+++ b/src/java/relex/output/LogicView.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * Alex van der Peet <alex.van.der.peet@gmail.com>
  */
 package relex.output;
@@ -67,15 +67,11 @@ public class LogicView
 	{
 		FeatureNode root = parse.getLeft();
 
-		FeatureNode headSet = new FeatureNode();
-		headSet.set("head", root.get("head"));
-		headSet.set("background", root.get("background"));
-
 		RuleSet relexRuleSet = _relex2LogicRuleLoader.getFreshRuleSet();
 
 		LogicProcessor ruleProcessor = new LogicProcessor(relexRuleSet);
 
-		String schemeOutput = ruleProcessor.applyRulesToParse(headSet);
+		String schemeOutput = ruleProcessor.applyRulesToParse(root);
 		schemeOutput = schemeOutput.replaceAll("sentence_index", "(ParseNode \"" + parse.getIDString() + "\")");
 
 		return schemeOutput;


### PR DESCRIPTION
Remove the code that tries to get the `head` node, since it is not even needed.  Fixes #38

Although it is still true that the `head` node is missing at the root of the Feature Structure that get passed, and `head-word` is pointing to a null value (again, at the root).  This is for the sentence "I walk and talk."

The only places where `head` and `head-word` is correct is at the node with`<HEAD-FLAG> = T`.  This correct `head`, and `head-word` do not propagate to the other node (I think since `F_R` do not points to the node with `<HEAD-FLAG> = T` for most other node).
