### PR TITLE
Allow regex in R2L rules' constants

### DIFF
--- a/data/relex2logic-rules.txt
+++ b/data/relex2logic-rules.txt
@@ -93,9 +93,9 @@
 # ============================================
 # passive verb rules
 # ============================================
-[PASSIVE1] {1} <PASSIVE2> _obj($A,$B) & by($A,$C) & tense($A,past_passive) => (passive-rule1 $A (get-instance-name $A word_index sentence_index) $B (get-instance-name $B word_index sentence_index) $C (get-instance-name $C word_index sentence_index))
+[PASSIVE1] {1} <PASSIVE2> _obj($A,$B) & by($A,$C) & tense($A, (.*)passive) => (passive-rule1 $A (get-instance-name $A word_index sentence_index) $B (get-instance-name $B word_index sentence_index) $C (get-instance-name $C word_index sentence_index))
 
-[PASSIVE2] {1} <PASSIVE1> _obj($A,$B) & tense($A,present_passive) => (passive-rule2 $A (get-instance-name $A word_index sentence_index) $B (get-instance-name $B word_index sentence_index))
+[PASSIVE2] {1} <PASSIVE1> _obj($A,$B) & tense($A, (.*)passive) => (passive-rule2 $A (get-instance-name $A word_index sentence_index) $B (get-instance-name $B word_index sentence_index))
 
 
 # ============================================

--- a/src/java/relex/logic/Criterium.java
+++ b/src/java/relex/logic/Criterium.java
@@ -59,9 +59,12 @@ public class Criterium {
 	{
 		_criteriumString = criterium;
 
-		_criteriumLabel = criterium.substring(0, criterium.indexOf("("));
+		// store the name of the RelEx relation
+		_criteriumLabel = criterium.substring(0, criterium.indexOf('('));
 
-		String criteriumVariables[] = criterium.substring(criterium.indexOf("(") + 1).replace(" ", "").replace(")", "").split(",");
+		// retrieve the variables and constants
+		String temp = criterium.substring(criterium.indexOf('(') + 1, criterium.lastIndexOf(')')).replace(" ",  "");
+		String criteriumVariables[] = temp.split(",");
 
 		_variables = Arrays.asList(criteriumVariables);
 	}

--- a/src/java/relex/output/LogicProcessor.java
+++ b/src/java/relex/output/LogicProcessor.java
@@ -656,7 +656,7 @@ public class LogicProcessor
 				{
 					// the first variable will always be the 'name' of the parent node
 					// XXX can also add checks to UUID, but would requires more logic for constants
-					if (!ruleResult.valuesMap.get(thisCriterium.getFirstVariableName()).equals(thisParent.get("name").getValue()))
+					if (!thisParent.get("name").getValue().matches(ruleResult.valuesMap.get(thisCriterium.getFirstVariableName())))
 					{
 						allMatched = false;
 						break;
@@ -671,9 +671,15 @@ public class LogicProcessor
 				// check the 2nd variable of this criterium
 				if (ruleResult.valuesMap.get(thisCriterium.getSecondVariableName()) != null)
 				{
+					String secondValue;
+
 					// the second value is at different place depends on whether the node is valued
-					if (!(thisNode.isValued() && ruleResult.valuesMap.get(thisCriterium.getSecondVariableName()).equals(thisNode.getValue()))
-							&& !(!thisNode.isValued() && ruleResult.valuesMap.get(thisCriterium.getSecondVariableName()).equals(thisNode.get("name").getValue())))
+					if (thisNode.isValued())
+						secondValue = thisNode.getValue();
+					else
+						secondValue = thisNode.get("name").getValue();
+
+					if (!secondValue.matches(ruleResult.valuesMap.get(thisCriterium.getSecondVariableName())))
 					{
 						allMatched = false;
 						break;


### PR DESCRIPTION
For the passive rule, mentioned in #89.  This change allows the passive rule to apply to any type of passive (present_passive, present_progressive_passive, past_passive, etc)
