### PR TITLE
change int to double for cost related calls

### DIFF
--- a/src/java/relex/RelationExtractor.java
+++ b/src/java/relex/RelationExtractor.java
@@ -77,7 +77,7 @@ public class RelationExtractor
 	public static final int DEFAULT_MAX_PARSES = 4;
 	public static final int DEFAULT_MAX_SENTENCE_LENGTH = 1024;
 	public static final int DEFAULT_MAX_PARSE_SECONDS = 30;
-	public static final int DEFAULT_MAX_PARSE_COST = 1000;
+	public static final double DEFAULT_MAX_PARSE_COST = 1000;
 
 	private boolean _is_inited;
 	private boolean _use_sock;
@@ -239,7 +239,7 @@ public class RelationExtractor
 		parser.setMaxLinkages(maxLinkages);
 	}
 
-	public void setMaxCost(int maxCost)
+	public void setMaxCost(double maxCost)
 	{
 		if (!_is_inited) init();
 		parser.getConfig().setMaxCost(maxCost);

--- a/src/java/relex/parser/LocalLGParser.java
+++ b/src/java/relex/parser/LocalLGParser.java
@@ -222,9 +222,9 @@ public class LocalLGParser extends LGParser
 			FeatureNode meta = new FeatureNode();
 			meta.set("num_skipped_words", new FeatureNode(Integer.toString(
 					LinkGrammar.getNumSkippedWords())));
-			meta.set("disjunct_cost", new FeatureNode(Integer.toString(
+			meta.set("disjunct_cost", new FeatureNode(Double.toString(
 					LinkGrammar.getLinkageDisjunctCost())));
-			meta.set("link_cost", new FeatureNode(Integer.toString(
+			meta.set("link_cost", new FeatureNode(Double.toString(
 					LinkGrammar.getLinkageLinkCost())));
 			meta.set("num_violations", new FeatureNode(Integer.toString(
 					LinkGrammar.getLinkageNumViolations())));


### PR DESCRIPTION
After pulling recent commits and updating link-grammar to 5.1.1 got the followinging error.

```
Exception in thread "main" java.lang.NoSuchMethodError: org.linkgrammar.LGConfig.setMaxCost(I)V
        at relex.RelationExtractor.setMaxCost(RelationExtractor.java:245)
        at relex.RelationExtractor.init(RelationExtractor.java:178)
        at relex.RelationExtractor.setAllowSkippedWords(RelationExtractor.java:250)
        at relex.RelationExtractor.main(RelationExtractor.java:518)
```

this is a fix for the above
