### PR TITLE
created missing predadj dependency for 'how adj' questions

### DIFF
--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -9,6 +9,7 @@
 ; Copyright (c) 2009,2014 Linas Vepstas
 ; Copyright (c) 2014 Rodas Solomon
 ; Copyright (c) 2014 Kasun Perera
+; Copyright (c) 2014 Aaron Nitzkin
 ;
 ;/////////////////////////////////////////////////////////////////////////////
 ;
@@ -95,7 +96,7 @@ FIND_PREDET_FOR_PREPS
 ; no conjunctions
 #TemplateActionAlg
 STANDARD_SUBJ
-<LAB> = \S\.*|\SX\.*|\Mg\.*|\MX\.*
+<LAB> = \S\.*|\SX\.*|\MX\.*
 <LAB> != \MX.[rj]\.*
 <LAB> != MX|MXs|MXp
 =
@@ -1364,7 +1365,7 @@ PREP_X
 ;
 #TemplateActionAlg
 PREP_PHRASE
-<LAB> = \J\.*|\ON\.*
+<LAB> = \J\.*|\ON\.*|\MG\.*|\Mgp
 =
 <F_L obj> = <F_R head-word>
 <F_L ref links _pobj> += <F_L obj>
@@ -1509,6 +1510,7 @@ PREP_RELATIVE_BACKGROUND
 <F_L background ref> += <F_R head-word ref>
 <F_L background wall> = <F_L wall>
 <F_L background BACKGROUND-FLAG> = T
+;
 
 ;
 ; You are happy because you are here.
@@ -1516,10 +1518,6 @@ PREP_RELATIVE_BACKGROUND
 ; I know that you are happy because you are here."
 ; You laugh because you are here.
 ; I know that you laugh because you are here.
-; ------
-; The preposition modifies the following phrase
-;    "On Tuesday, we left."
-; Wont apply to "Often, we left" because 'often' has no obj
 ;
 
 ;
@@ -1531,37 +1529,92 @@ OPENING_PREP_ADVERBIAL
 <LAB> = \CO\.*
 <F_L POS> = prep
 =
-<F_R head-word ref links _prepadv> = <F_L ref>
+<F_R head-word ref links _prepadv> += <F_L ref>
 
 #TemplateActionAlg
 OPENING_ADVERBIAL
 <LAB> = \CO\.*
 <F_L POS> != prep
 =
-<F_R head-word ref links _advmod> = <F_L ref>
+<F_R head-word ref links _advmod> += <F_L ref>
 
-#PrepositionLinkAlg
-PREP_CLAUSE_OBJECT
-; The preposition modifies the preceeding phrase
-<LAB> = MVs|\TH\.*|\WN\.*
-<F_L head-word> != %
-<F_L head-word> = $modified
-<F_R str> = $prep
-<F_R> = $prep_source
-<F_R head-word ref> = $prep_obj
-=
 ;
-#PrepositionLinkAlg
-PREP_CLAUSE_OBJECT2
-; The preposition modifies the preceeding phrase
-<LAB> = MVs|\TH\.*|\WN\.*
-<F_L head-word> = %
-<F_L> = $modified
-<F_R str> = $prep
-<F_R> = $prep_source
-<F_R head-word ref> = $prep_obj
-=
+; The following series of algs create some complement phrases
+; and hook them up to the things they modify, picking out some
+; which already have more speciic relations, -- because, when,
+; and introducing rep() for 'representation' as in 'I think that . . .'
+; these really aren't all related stuff, but they were all previously
+; conflated in one rule in this section, so they get revised here . . .
+; (AN Dec 2014)
 ;
+#TemplateActionAlg
+COMP_PHRASE
+<LAB> = \C\.*
+<F_L POS> != verb|adj
+=
+<F_L ref links _comp> += <F_R head-word ref> 
+
+#TemplateActionAlg
+OMITTED_THAT_COMP
+<LAB> = \Ce\.*
+<F_L POS> = verb|adj
+=
+<F_L ref links _rep> += <F_R head-word ref>
+
+#TemplateActionAlg
+COMP_MOD
+<LAB> = \MVs
+<F_R str> != because|since|considering|when
+=
+<F_L ref links _compmod> += <F_R ref>
+
+;
+; _rep is the relation of representing something,
+; mentally or verbally; it requires a unique relation
+; because it affects the inferences that can be made
+; about the content within its scope.
+; 
+#TemplateActionAlg
+REP_COMP
+<LAB> = \TH\.*|
+=
+<F_L ref links _rep> += <F_R ref>
+
+;
+; So far, can't find a sentence that uses this link --
+; maybe the dictionary documentation is outdated . . .
+;
+#TemplateActionAlg
+WHEN_COMP
+<LAB> = \WN\.*|\MVs
+<F_R str> = when|while
+=
+<F_L ref linke _%atTime> += <F_R ref>
+
+#TemplateActionAlg
+BECAUSE_COMP
+<LAB> = \MVs
+<F_R str> = because|since
+=
+<F_L ref links _%because> += <F_R ref>
+
+;
+; I can't see how this rule handled anything not handled by the
+; rules above that I just wrote, but I'm not sure, so I'm not
+; deleting it yet . . .
+;
+;#PrepositionLinkAlg
+;PREP_CLAUSE_OBJECT2
+; The preposition modifies the preceeding phrase
+;<LAB> = MVs|\TH\.*|\WN\.*
+;<F_L head-word> = %
+;<F_L> = $modified
+;<F_R str> = $prep
+;<F_R> = $prep_source
+;<F_R head-word ref> = $prep_obj
+;=
+;
+
 #PrepositionLinkAlg
 PRECEEDING_PREP_CLAUSE_OBJECT
 ; The preposition modifies the following phrase

--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -1375,7 +1375,7 @@ DANGLING_PREP_LINK1
 <F_L str> = who|Who|whom|Whom|what|What
 =
 <F_R obj> = <F_L head-word>
-<F_R ref links _pobj> += <F_L obj>
+<F_R ref links _pobj> += <F_L ref>
 ;
 #TemplateActionAlg
 PREP_ADJECTIVAL

--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -2098,7 +2098,7 @@ ADV1_ONLY_IF_NOT_PREP
 #TemplateActionAlg
 ADV2
 <LAB> = \E\.*|\EA\.*
-<LAB> != \Eq\.*|\EA[my]\.*
+<LAB> != \Eq\.*|\EA[my]\.*|\EAh
 <F_R head-word ref> != %
 =
 <F_R head-word BACKGROUND-FLAG> = T
@@ -2111,7 +2111,7 @@ ADV2
 #TemplateActionAlg
 ADV2_HEADLESS
 <LAB> = \E\.*|\EA\.*
-<LAB> != \Eq\.*|\EA[my]\.*
+<LAB> != \Eq\.*|\EA[my]\.*|\EAh
 <F_R head-word ref> = %
 =
 <F_R BACKGROUND-FLAG> = T
@@ -2127,9 +2127,8 @@ ADV2_HEADLESS
 #TemplateActionAlg
 ADV3
 <LAB> = \EE\.* | EA
-<LAB> != \EEy | \EAy
+<LAB> != \EEy | \EAy|\EEh |\EAh
 <F_L str> != more
-<F_L str> != how|How
 =
 <F_R BACKGROUND-FLAG> = T
 <F_R ref links _advmod> += <F_L ref>
@@ -2143,7 +2142,7 @@ ADV3
 #TemplateActionAlg
 ADV3_1
 <LAB> = \EE\.*
-<LAB> != \EEy
+<LAB> != \EEy|\EEh
 <F_R linkL0 LAB> = \MVa
 =
 <F_R BACKGROUND-FLAG> = T
@@ -2169,7 +2168,7 @@ ADV3_2
 
 #TemplateActionAlg
 ADV3_3_HowDegQ
-<LAB> = \EEh
+<LAB> = \EEh|\EAh
 =
 <F_R BACKGROUND-FLAG> = T
 <F_R ref links _%howdeg> += <F_L ref>

--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -706,7 +706,14 @@ HEAD_TO_FIRST_VERB
 <HEAD-FLAG> = T
 =
 <tense first_verb head-word> += <this>
-;
+
+#TemplateActionAlg
+INFINITIVE_HEAD_VERB
+<LAB> = \I\.*
+<F_L head-word> = %
+=
+<F_L head-word> = <F_R ref>
+
 #TemplateActionAlg
 HEAD_TO_SUBJ_AND_OBJ1
 <LAB> = \S\.*|\SX\.*|\B.w\.*|\SF\.*
@@ -718,7 +725,7 @@ HEAD_TO_SUBJ_AND_OBJ2
 <LAB> = \S\.*|\SX\.*
 =
 <F_L head-word> += <F_R head-word>
-;
+
 #TemplateActionAlg
 HEAD-QUESTION-WORD
 ;  Who does John think the man I love wants?
@@ -859,6 +866,7 @@ DECLARATIVE_QUESTION1
 DECLARATIVE_QUESTION2
 ; not AND-SAFE!
 ; regular expression [\\?] matches just the question mark
+
 <LAB> = \Wd\.*
 <F_L punc> = \[\\?]
 <F_L head-word> != %
@@ -866,7 +874,19 @@ DECLARATIVE_QUESTION2
 <F_R head-word ref TRUTH-QUERY-FLAG> = T
 <F_R head-word ref HYP> = T
 <F_L wall sentence_type> = QUERY
+
 ;
+; Needed to complete dependency of some preposed prep-phrases on verb
+; ('to whom did you sell the children?")
+;
+
+#TemplateActionAlg
+CONNECT_PREPOSED_PREP_QWORD_TO_VERB
+<LAB> = Qd
+<F_L POS> = prep
+=
+<F_R head-word ref links _advmod> += <F_L ref>
+
 #TemplateActionAlg
 QUESTIONS-COPULA
 <LAB> = Q|Qd
@@ -884,7 +904,7 @@ WHEN
 <F_L ref name> = %
 <F_L ref name> = _$qVar
 <F_L ref QUERY-TYPE> = when
-<F_L head-question-word ref links _%atTime> = <F_L ref>
+<F_L head-question-word ref links _%atTime> += <F_L ref>
 ;
 ; Rule below not working, not sure why yet . . . 
 ;
@@ -893,7 +913,7 @@ PREPWHEN
 <LAB> = \D\.*
 <F_L ref QUERY-TYPE> = when
 =
-<F_L head-question-word ref links _%atTime> = <F_L ref>
+<F_L head-question-word ref links _%atTime> += <F_L ref>
 ;
 #TemplateActionAlg
 ; This algoritm was modified to exclude cases where there isn't a todo 
@@ -1164,15 +1184,6 @@ HEAD-WORD_GROUP6
 ;/////////////////////////////////////////////////////////////////////////////
 ;
 ;
-#TemplateActionAlg
-THAT1
-<LAB> = \C[ei]\.*
-<LAB> != \Cet\.*
-; Ce is direct complement of verb (Cet means 'that' is present)
-; 'that' is handled in preposition section. (PREP_CLAUSE_OBJECT)
-=
-<F_L that> += <F_R head-word ref>
-;
 
 #TemplateActionAlg
 RELATIVE_CLAUSE_TO_BACKGROUND
@@ -1356,6 +1367,7 @@ PREP_X
 #TemplateActionAlg
 PREP_PHRASE
 <LAB> = \J\.*|\ON\.*|\MG\.*|\Mgp
+<F_L POS> = prep
 =
 <F_L obj> = <F_R head-word>
 <F_L ref links _pobj> += <F_L obj>
@@ -1383,6 +1395,38 @@ PARTICIPIAL_ADJECTIVAL
 <F_L ref links _amod> += <F_R ref>
 
 ;
+; Theorder of rules here may seem odd, but it's absolutely necessary because
+; one has to set certain flags to prevent MVp adverbs from getting classified in certain ways. . . 
+; (AN DEC 2014)
+;
+
+#TemplateActionAlg
+EQUATIVE_COMPARATIVE_FIRST_DEGREE
+<LAB> = \EEy\.*
+=
+<F_R COMPARED_MOD_FLAG> = T
+<F_R BACKGROUND-FLAG> = T
+<F_R ref links _compdeg> += <F_L ref>
+
+#TemplateActionAlg
+COMPARATIVE_CONTEXT
+<LAB> = \MVa\.*
+<F_R COMPARED_MOD_FLAG> = T
+<F_L linkR2> != %
+=
+<F_R ref links _compcontadv1> += <F_L linkR1 F_R ref>
+<F_L ref links _compadvmod> += <F_R ref>
+<F_L linkR1 F_R COMPCONT_FLAG> = T
+
+#TemplateActionAlg
+COMPARATIVE_SECOND_CONTEXT
+<LAB> = \CX\.*
+<F_L linkL0 F_L linkR1 F_R COMPCONT_FLAG> = T
+=
+<F_L linkL0 F_L linkR2 F_R ref links _compcontadv2> += <F_R linkR0 F_R ref>
+<F_L COMPCONT_FLAG> = T
+
+;
 ; The exception in the rule below is for cases where an adverb intervenes
 ; between a verb and the prep-adv as in "He ran largely in the morning."
 ; Note; I'm not sure there's any reason prepositional adverbials need their
@@ -1392,8 +1436,16 @@ PARTICIPIAL_ADJECTIVAL
 PREP_ADVERBIAL
 <LAB> = \MVp\.*|\OF\.*|\LI\.*|\Pp\.*
 <F_L POS> != adv
+<F_R COMPCONT_FLAG> !=T
+<F_L COMPCONT_FLAG> !=T
 =
 <F_L ref links _advmod> += <F_R ref>
+
+#TemplateActionAlg
+IMPLICIT_COMPARED_MOD
+<LAB> = \CX\.*
+=
+<F_R ref links _advmod> += <F_L linkL0 F_L ref links _advmod>
 
 ;
 ; This is supposes to create the advmod of a prep by any adverbial
@@ -1406,12 +1458,6 @@ ADVMOD_OF_ADVERBIAL
 =
 <F_R ref links _advmod> += <F_L ref>
 <F_L modified> += <F_R ref>
-
-;
-; NB!!! I suspect that virtually all of the preposition rules either already
-; are or will be completely useless when I'm done writing new ones above this
-; note but I'm not deleting any until I finish. (AN DEc 2014)
-;
 
 ;
 ; This is a misplaced question rule: "Where did John put it?"
@@ -1433,21 +1479,6 @@ POSSR_TO_APOSTROPHE
 <F_R possessor> += <F_L ref>
 
 ;
-;e.g. Mike runs as fast as he did last year.
-;this forms "as(fast, he)" relationship
-;CX is used in comparative constructions like "as I do"
-;
-#PrepositionLinkAlg
-PREP_LINKING
-<LAB> = \MVz\.*
-<F_R linkR0 LAB> = \CX
-<F_L prep-temp> != %
-<F_L prep-temp> = $modified
-<F_R str> = $prep
-<F_R> = $prep_source
-<F_R linkR0 F_R subj> = $prep_obj
-=
-;
 ; Apparently MVi is reserved for (in order) to
 ;
 #TemplateActionAlg
@@ -1468,7 +1499,7 @@ ADVMOD_OF_PREP
 <F_R POS> = prep
 =
 <F_R ref links _advmod> += <F_L ref>
-<F_L modified> = <F_R ref>
+<F_L modified> += <F_R ref>
 
 #TemplateActionAlg
 ADVERB_OBSTRUCTED_PREPADV
@@ -1498,6 +1529,7 @@ INVERSE_RELATIVE_PREP
 =
 <F_R ref links _advmod> = <F_L ref>
 <INVERSE-REL-PREP FLAG> = T
+
 ;
 ; Delete the _prepadj relation for "The man on whom we sat."
 ;
@@ -1662,6 +1694,7 @@ ADJ1
 =
 <F_R BACKGROUND-FLAG> = T
 <F_R ref links _amod> += <F_L ref>
+
 ;
 ; Treat preps without objects as adjectives -- copula (Pp) is treated
 ; separately.
@@ -1691,6 +1724,7 @@ ADJ2_2
 =
 <F_L BACKGROUND-FLAG> = T
 <F_L ref links _amod> += <F_R ref>
+
 ;this rules applies for adjective-focused comparatives
 ;e.g. My sister is much more intelligent than me.
 ; ECa is used in connection (much,more) and more is acting as a adjectival adverb for "intelligent".
@@ -1902,6 +1936,7 @@ CONJ_AMOD
 <F_R ref links _amod> = %
 <F_R ref links _amod> += <F_L conj member0 ref>
 <F_R ref links _amod> += <F_L conj member1 ref>
+
 #TemplateActionAlg
 CONJ_PREDADJ
 <F_L subj links _predadj> != %
@@ -1926,84 +1961,44 @@ CONJ_PREDADJ
 ;the word "more" is serving as an adverb to "quickly".( adverbial comparative)
 ;In this case, the connector between "more" and "quickly" is specially
 ;subscripted with "EEm" (the special subscript "m") to handle such "more/less" cases.
-#TemplateActionAlg
-COMPARATIVE_MVa-EE
-<LAB> = \MVa
-<F_R linkL1 LAB> = \EEm
-=
-<F_R ref degree> = comparative
 ;
 ;e.g - He is more/less intelligent than John.
 ;"more" is serving as an adjectival adverb
 ;In this case, the connector between "more/less" and "intelligent" is specially
 ;subscripted with "EAm" (the special subscript "m") to handle such "more/less" cases.
-#TemplateActionAlg
-COMPARATIVE_Pa-EAm
-<LAB> = \Pa\.*
-<F_R linkL1 LAB> = \EAm
-=
-<F_R ref degree> = comparative
 ;
 ;e.g - I find maths lessons more/less enjoyable than science lessons.
 ;"more" is serving as an adjectival adverb
 ;In this case, the connector between "more/less" and "enjoyable" is specially
 ;subscripted with "EAm" (the special subscript "m") to handle such "more/less" cases.
+
 #TemplateActionAlg
-COMPARATIVE_Ma-EAm
-<LAB> = \Ma
-<F_R linkL1 LAB> = \EAm
+COMPARATIVE_ONE
+<LAB> = \EEm\.*|\EAm\.*
 =
-<F_R ref degree> = comparative
+<F_R ref links _compdeg> += <F_L ref>
 
 ;e.g. He is more/less intelligent than attractive.
 ;the connector between "more/less" and "is" is specially
 ;subscripted with "EBmm" (the special subscript "mm") and "is" and "intelligent" connected with "Paf" link
 #TemplateActionAlg
-COMPARATIVE_Pa-EBmm
-<LAB> = \Pa\.*
-<F_L linkR1 LAB> = \EBmm
+COMPARATIVE_TWO
+<LAB> = \Pa\.*|\MVt
+<F_L linkR1 LAB> = \EBmm|\Omm|\Om\MVm
 =
-<F_R ref degree> = comparative
+<F_R ref links _compdeg> = <F_L linkR1 F_R ref>
 
 ;He did it more/less quickly than carefully.
-#TemplateActionAlg
-COMPARATIVE_MVa-MVm
-<LAB> = \MVa
-<F_L linkR2 LAB> = \MVm
-=
-<F_R ref degree> = comparative
-;
 ;e.g - He runs more/less quickly than John does.
-;In this case, the connector between "more/less" and "quickly" is specially
-;subscripted with "Om" (the special subscript "m") to handle such "more/less" cases.
-;Note- The "He runs less quickly than John does" sentence is ungrammatical. 
-;But sentence is commonly used by non-native English speakers.
-;So below rule is adding support for common, ungrammatical sentences.
-#TemplateActionAlg
-COMPARATIVE_MVa-Om
-<LAB> = \MVa
-<F_L linkR2 LAB> = \Omm | \Om
-=
-<F_R ref degree> = comparative
-;
 ;e.g - He runs more/less than John.
-;In this case, the connector between "more/less" and "quickly" is specially
-;subscripted with "Om" (the special subscript "m") to handle such "more/less" cases.
-#TemplateActionAlg
-COMPARATIVE_MVt-Om
-<LAB> = \MVt
-<F_L linkR1 LAB> = \Omm | \Om
-=
-<F_L linkR1 F_R ref degree> = comparative
 ;e.g - He runs less miles than John does.
-;In this case, the connector between "less" and "runs" is specially
-;subscripted with "Om" (the special subscript "m") to handle such "less" cases.
 #TemplateActionAlg
-COMPARATIVE_MVp-Om
-<LAB> = \MVp
-<F_L linkR2 LAB> = \Omm | \Om
+COMPARATIVE_THREE
+<LAB> = \MVa\.*|\MVp\.*
+<F_L linkR2 LAB> = \MVm|\Omm | \Om
 =
-<F_L linkR2 F_R ref degree> = comparative
+<F_R ref links _compdeg> = <F_L linkR2 F_R ref>
+
 ;
 ;Here "more" is serving as a noun-phrase, the number of the noun in the "more" phrase is
 ;indicated by the D link ( it should be either noun-phrase  or as determiner of
@@ -2011,11 +2006,11 @@ COMPARATIVE_MVp-Om
 ;singular, whereas if it is "Dmcm", the noun is plural.
 ;Here it forms the degree relationship of the noun-phrase
 #TemplateActionAlg
-COMPARATIVE_Dmum
-<LAB> = \Dmcm | \Dmum
-<F_L str> = more|much|less|fewer
+QUANTITY
+<LAB> = \Dm\.*
 =
-<F_L ref degree> = comparative
+<F_R ref links _quantity> = <F_L ref>
+
 ;
 ;/////////////////////////////////////////////////////////////////////////////
 ;
@@ -2040,57 +2035,37 @@ ADV1
 <F_R str> != not|more|less
 <F_L head-word> != %
 <F_R degree> = %
+<F_R COMPCONT_FLAG> != T
+<F_L COMPCONT_FLAG> != T
 =
 <F_L head-word BACKGROUND-FLAG> = T
 <F_L head-word ref links _advmod> += <F_R ref>
 
 ;
-; -------------------------------------------------------------
-; Adverb usage in comparaitves
-;
-;e.g. He runs less quickly than John does.
-;Above ADV1 rule only makes _advmod(run, quickly) but we want to make infer that he
-;runs (quickly,less)
-;Following rule make the  binary relationship _advmod(quickly, less)
-;Note- The above example sentence is ungrammatical. 
-;But sentence is commonly used by non-native English speakers.
-;So below rule is adding support for common, ungrammatical sentences. 
-#TemplateActionAlg
-ADV1_1
-<LAB> = \MVa
-<F_R str> != not|more|less
-<F_L head-word> != %
-<F_R degree> = %
-<F_L linkR2 F_R str> = more|less 
-=
-<F_R ref links _advmod> += < F_L linkR2 F_R ref>
-;
-;
 ;e.g. He runs faster than John.
 ;Above ADV1 rule won't make _advmod(run, fast) relationship due to "faster" is 
 ;POS tagged with ".a-c" and relex-tagging.algs make it's degree as comparative.
 ;Following rule make the  binary relationship _advmod(run, fast)
+
 #TemplateActionAlg
 ADV1_2
-<LAB> = \MVb
+<LAB> = \MVb\.*
 <F_R str> != not|more|less|often
-<F_L head-word> != %
 <F_R degree> != %
-<F_L head-word BACKGROUND-FLAG> != T 
 =
 <F_L head-word BACKGROUND-FLAG> = T
-<F_L head-word ref links _advmod> += <F_R ref>
+<F_R ref links _compdeg> += more
+
 ;
 ; MVp : "find elsewhere" e.g.  "... than you can find elsewhere."
 ; XXX should check if left-word is a verb?; if its not then its an amod .. !?
 ; We need explicit right-word-not-prep check to handle the usual; MVp
 ; cases.
 ;
-; Bug-fix (10-9-2014 AN): last condition below added to prevent a "to" that
-; introduces an indirect object from being interpreted as an advmod. Created
-; TO_IOBJ_FLAG relex-taggin file so as not to have to disallow all "to"'s from
-; advmod here, such as "to the nth degree."
+; Created TO_IOBJ_FLAG relex-taggin file so as not to have to disallow all "to"'s from
+; advmod here, such as "to the nth degree." (AN)
 ;
+
 #TemplateActionAlg
 ADV1_ONLY_IF_NOT_PREP
 <LAB> = \MVp\.*
@@ -2098,9 +2073,12 @@ ADV1_ONLY_IF_NOT_PREP
 <F_L head-word> != %
 <F_R PREP-OBJ> = %
 <F_R Q_TO_IOBJ_FLAG> != T
+<F_R COMPCONT_FLAG> != T
+<F_L COMPCONT_FLAG> != T
 =
 <F_L head-word BACKGROUND-FLAG> = T
 <F_L head-word ref links _advmod> += <F_R ref>
+
 ;
 ; Jim quickly runs.
 ; Jim is very tired.
@@ -2112,6 +2090,7 @@ ADV2
 =
 <F_R head-word BACKGROUND-FLAG> = T
 <F_R head-word ref links _advmod> += <F_L ref>
+
 ;
 ; The head-word can be blank in unusual or quirky parses, for example:
 ; "There are also bogus plans" where "bogus" is the head, instead of "are".
@@ -2141,6 +2120,7 @@ ADV3
 =
 <F_R BACKGROUND-FLAG> = T
 <F_R ref links _advmod> += <F_L ref>
+
 ;EE connects adverbs to other adverbs. Some adverbs can
 ;modify other adverbs ("very", "quite"); these carry EE+connectors.
 ;e.g. I run more often than Ben.
@@ -2156,20 +2136,6 @@ ADV3_1
 =
 <F_R BACKGROUND-FLAG> = T
 <F_R ref links _advmod> += <F_L ref>
-
-;e.g. The snail is running  exactly as fast as the cheetah.
-;_advmod(fast, exactly)
-;case <F_R linkL0 F_L head-word> = %  e.g. Mike runs as fast as he did last year.
-;for above sentence we need to avoid it forming both _advmod(run, fast) AND _advmod(fast, run),
-
-#TemplateActionAlg
-ADV3_2
-<LAB> = \EEy
-<F_R linkL0 LAB> = \MVa
-<F_R linkL0 F_L head-word> = %
-=
-<F_R BACKGROUND-FLAG> = T
-<F_R ref links _advmod> += <F_R linkL0 F_L ref>
 
 ; The below is added to handle the how in 'how-of-degree questions' as in 'how quickly does he run'
 ; which were previously being picked up by the rules above and pre-empting the r2l advmod rule; 
@@ -2193,6 +2159,7 @@ ADV4
 <F_L POS> = adv
 <F_R head-word BACKGROUND-FLAG> = T
 <F_R head-word ref links _advmod> += <F_L ref>
+
 ;
 ; Fix up conjunctions; link not to the conjunction,
 ; but to each conjoined modifier.
@@ -2207,33 +2174,26 @@ CONJ_ADVMOD
 <F_L ref links _advmod> = %
 <F_L ref links _advmod> += <F_R conj member0 ref>
 <F_L ref links _advmod> += <F_R conj member1 ref>
-;
-;EC connects adverbs and comparative adjectives:
-;EA connects adverbs to adjectives.
-#TemplateActionAlg
-COMP_ADVMOD_1_1
-<LAB> = \EBmm|\MVm|\EAm
-<F_R str> = less | more
-=
-<F_L advmod> += <F_R ref>
-;EC connects adverbs and comparative adjectives
-;ECn is used for noun-focused comparative
+
+;EC connects adjectives and adverbs with comparative adverbs
 ;e.g. It is much bigger
 #TemplateActionAlg
 COMP_ADVMOD_1_2
-<LAB> = \ECn
+<LAB> = \EC\.*
 =
-<F_R advmod> += <F_L ref>
+<F_R ref links _compdeg> += <F_L ref>
+
 #TemplateActionAlg
 ;Pizza, which most people love, is not very healthy.
 ;to handle binary relationship _advmod(very,not)
 COMP_ADVMOD_2_1
-<LAB> = \Paf
+<LAB> = \Paf\.*
 <F_L advmod> != %
 <F_R linkL1 F_L> != %
 =
 <F_R linkL1 F_L ref links _advmod> += <F_L advmod> 
 <F_L advmod> = %
+
 #TemplateActionAlg
 COMP_ADVMOD_2_2
 <LAB> = \Pa\.*
@@ -2241,12 +2201,14 @@ COMP_ADVMOD_2_2
 =
 <F_R ref links _advmod> += <F_L advmod>
 <F_L advmod> = %
+
 #TemplateActionAlg
 COMP_ADVMOD_3
 <LAB> = \EAm
 <F_L str> = less|more
 =
 <F_R advmod> += <F_L ref>
+
 ;case "<F_L str> != much" was introduced to form relationships such as _advmod(more, much)
 ;e.g. My sister is much more intelligent than me. 
 ;would form a _advmod(more, much) relationship without above condition 
@@ -2257,6 +2219,7 @@ COMP_ADVMOD_4
 <F_L str> != much
 =
 <F_R ref links _advmod> += <F_L ref>
+
 #TemplateActionAlg
 COMP_ADVMOD_5_1
 <LAB> = \Op
@@ -2264,11 +2227,13 @@ COMP_ADVMOD_5_1
 =
 <F_L ref links _advmod> += <F_R advmod>
 <F_R advmod> = %
+
 #TemplateActionAlg
 ADVMOD_TO_LINKS
 <advmod> != %
 =
 <ref links _advmod> = <advmod>
+
 ;/////////////////////////////////////////////////////////////////////////////
 ;
 ; Parataxis
@@ -2303,8 +2268,8 @@ QUESTION_HEAD_HYP
 ;
 ; NOUN MODIFICATION
 ;
-;
-;
+;//////////////////////////////////////////////////////////////////////////
+
 #TemplateActionAlg
 NOUN-MOD
 <LAB> = \AN\.*
@@ -2368,8 +2333,8 @@ POSSR_TO_DET
 ;
 ; QUANTITY DETERMINERS
 ;
-;
-;
+;////////////////////////////////////////////////////////////////////////////
+
 #TemplateActionAlg
 QUERY_INDEFINATE_DETERMINER1
 ;identfies indefinate determiners for the purpose of queries.  For instance: 
@@ -2381,7 +2346,7 @@ QUERY_INDEFINATE_DETERMINER1
 <F_L str> = a|A|an|An|some|Some|any|Any
 =
 <F_L QUERY_INDEFINATE_DETERMINER_FLAG> = T
-;
+
 #TemplateActionAlg
 QUERY_INDEFINATE_DETERMINER2
 ; Identfies indefinate determiners for the purpose of queries.  For instance: 
@@ -2403,6 +2368,7 @@ QUANTITY_EXCEPTION
 <F_L str> = more|More|less|Less|'s|fewer|Fewer|'|’s|’
 =
 <F_L QUANTITY-EXCEPTION-FLAG> = T
+
 ;e.g. "I have more chairs than Ben." Here "more" is used to indicate the quantity of chairs
 ;to form the relationship _quantity(chair, more)  \Dmcm and \Op connectors are used. 
 ;Os- and Op- connectors mark nouns as being singular or plural. 
@@ -2417,6 +2383,7 @@ QUANTIFIERS_1
 <F_L linkL0 LAB> != \ND
 =
 <F_R ref links _quantity> = <F_L ref>
+
 ;
 ; Currently, the IS-NUMBER-FLAG is used only by the Penn tagging algs.
 ;
@@ -2433,12 +2400,14 @@ NUMBER-1
 =
 <F_R ref links _quantity> = <F_L ref>
 <F_L IS-NUMBER-FLAG> = T
+
 ;
 ;#TemplateActionAlg
 ;NUMBER-2
 ;<LAB> = \AL\.*
 ;=
 ;<F_R temp_q> += <F_L ref>
+
 ;#TemplateActionAlg
 ;NUMBER-3
 ;<LAB> = \D\.*
@@ -2450,6 +2419,7 @@ NUMBER-1
 ;the "m" subscript is for "multiple", the "c" subscript is for "count"
 ;so "n" here indicates "numeric". 
 ;This connector has essentially the same meaning as the ND numeric determiner.
+
 #TemplateActionAlg
 NUMBER-NUMERIC-QUANTIFIERS
 <LAB> = \Dmcn 
@@ -2460,6 +2430,7 @@ NUMBER-NUMERIC-QUANTIFIERS
 =
 <F_R ref links _quantity> = <F_L ref>
 <F_L IS-NUMBER-FLAG> = T
+
 ;
 ;Different uses of the NI connectors are handled separately. 
 ;
@@ -2478,10 +2449,10 @@ NUMBER-1a
 <F_R linkR0 F_R ref links _quantity> = <F_L ref>
 <F_L IS-NUMBER-FLAG> = T
 <F_R NOT_NUMBER_FLAG> = T
+
 ;
 ;The three algorithmhs below (NUMERICAL_RANGES_L, NUMERICAL_RANGES_R, NUMBER-NUMERICAL_RANGES)
 ;handle the sentence "It is from 6 to 7 m in length." -- _quantity(m, 6), _quantity(m, 7)
-;
 ;
 #TemplateActionAlg
 NUMERICAL_RANGES_L
@@ -2489,6 +2460,7 @@ NUMERICAL_RANGES_L
 <F_L NOT_NUMBER_FLAG> = %
 =
 <F_R numerical_ranges> += <F_L>
+
 ;
 #TemplateActionAlg
 NUMERICAL_RANGES_R
@@ -2496,6 +2468,7 @@ NUMERICAL_RANGES_R
 <F_R NOT_NUMBER_FLAG> = %
 =
 <F_L numerical_ranges> += <F_R>
+
 ;
 #TemplateActionAlg
 NUMBER-NUMERICAL_RANGES
@@ -2509,6 +2482,7 @@ NUMBER-NUMERICAL_RANGES
 <F_R ref links _quantity> += <F_L numerical_ranges member1 ref>
 <F_L numerical_ranges member0 IS-NUMBER-FLAG> = T
 <F_L numerical_ranges member1 IS-NUMBER-FLAG> = T
+
 ;
 ;Handles all other cases of NI connectors
 ;
@@ -2647,7 +2621,9 @@ QUESTION_DETERMINER
 ; Cornwallis was expecting more troops to arrive on British ships.
 ; The undergrads are gloomier than usual.
 ; She eats more pasta.
-; -----
+; 
+;//////////////////////////////////////////////////////////////////////////////
+
 ;
 ; Marks the comparative subject with a reference to the relation word
 ;    Dave eats more/as_many cats than/as... (D**m/D**y)
@@ -2726,6 +2702,7 @@ RELATION_THAN_3
 <F_L set> = T
 <F_L comp_temp> += <F_R temp>
 <F_R temp> = %
+
 #TemplateActionAlg
 RELATION_THAN_4
 <LAB> = \O\.*|\C\.*|\S\.*|\U\.*|\Bc
@@ -2736,6 +2713,7 @@ RELATION_THAN_4
 <F_L comp_temp> = %
 <F_L comp_temp> += <F_R ref>
 <F_R comp_temp> = %
+
 ;e.g. He earns more than I expected
 ;For this, "than" is given an Zc+ connector. 
 ;Z is also used in subordinate "as"-phrases like "He left, as I expected".
@@ -2789,7 +2767,6 @@ RELATION_THAN_6_2
 =
 <F_L comp_temp> += <F_R ref>
 
-
 #TemplateActionAlg
 RELATION_THAN_6_3
 <LAB> = \MVt
@@ -2797,6 +2774,7 @@ RELATION_THAN_6_3
 =
 <F_L ref links than> += <F_R comp_temp_1>
 <F_R comp_temp_1> = %
+
 ;MVz is used in comparatives with "As" 
 ;e.g. The snail is running  exactly as fast as the cheetah.
 ;MVp e.g.  Jack’s hair color is similar to Ben's
@@ -2809,6 +2787,7 @@ RELATION_THAN_7
 <F_L comp_temp> = %
 <F_L comp_temp> += <F_R comp_temp>
 <F_R comp_temp> = %
+
 #TemplateActionAlg
 RELATION_THAN_8
 ;<LAB> = \Pa\.*|\I\.*
@@ -2817,6 +2796,7 @@ RELATION_THAN_8
 =
 <F_L comp_temp> += <F_R comp_temp>
 <F_R comp_temp> = %
+
 #TemplateActionAlg
 RELATION_THAN_9_1
 <LAB> = \Paf
@@ -2824,6 +2804,7 @@ RELATION_THAN_9_1
 =
 <F_L comp_var> += <F_R comp_temp>
 <F_R comp_temp> = %
+
 ;differentiate forming "than()" relationships when connected with "Ma" links
 ;e.g. I find maths lessons more enjoyable than science lessons. vs I find maths more difficult than science.
 ;
@@ -2835,6 +2816,7 @@ RELATION_THAN_9_2
 =
 <F_L comp_var> += <F_R comp_temp>
 <F_R comp_temp> = %
+
 #TemplateActionAlg
 RELATION_THAN_10
 <LAB> = \Opn
@@ -2843,6 +2825,7 @@ RELATION_THAN_10
 <F_R SET> = T
 <F_L comp_var> += <F_R comp_var>
 <F_R comp_var> = %
+
 #TemplateActionAlg
 RELATION_THAN_11
 <LAB> = \MVp
@@ -2853,6 +2836,7 @@ RELATION_THAN_11
 <F_R comp_var> += <F_L comp_temp>
 <F_L comp_temp> = %
 ;
+
 #TemplateActionAlg
 RELATION_THAN_12
 <LAB> =\Ma
@@ -2871,7 +2855,7 @@ RELATION_THAN_13
 <F_R ref links than> += <F_L comp_var>
 <F_L comp_var> = %
 
-; XXX FIXME WTF? .. why is the below looking at teh gender !!??
+; XXX FIXME WTF? .. why is the below looking at gender !!??
 #TemplateActionAlg
 RELATION_THAN_14
 <LAB> = \MV\.*|\Usc\.*|\Os\.*
@@ -2881,6 +2865,7 @@ RELATION_THAN_14
 =
 <F_L comp_temp1> += <F_R ref>
 ;
+
 #TemplateActionAlg
 RELATION_THAN_15
 <LAB> = \MVt\.*
@@ -2889,6 +2874,7 @@ RELATION_THAN_15
 <F_L comp_temp1> += <F_R comp_temp1>
 <F_R comp_temp1> = %
 ;
+
 #TemplateActionAlg
 RELATION_THAN_16
 <LAB> =\Ou\.*
@@ -2902,6 +2888,7 @@ RELATION_THAN_16
 ;e.g. I have fewer chairs than Ben. So this this sentence we want to form the than()
 ;relationship using rule "RELATION_THAN_17_2". The rule "RELATION_THAN_17_1" would form 
 ;than(chair, Ben) which is wrong, where correct form should be than(I, Ben) 
+
 #TemplateActionAlg
 RELATION_THAN_17_1
 <LAB> = \Op
@@ -2937,6 +2924,7 @@ RELATION_THAN_17_3
 <F_R comp_temp> = %
 <F_R comp_temp1> = %
 ;
+
 #TemplateActionAlg
 RELATION_THAN_18
 <LAB> = \MVa
@@ -2944,6 +2932,7 @@ RELATION_THAN_18
 =
 <F_R ref links than> += <F_L comp_temp1>
 <F_L comp_temp1> = %
+
 ;
 ;Rule for Dependency Relation "than1".comp_temp1 is used for temporary storage purpose.
 #TemplateActionAlg
@@ -2953,6 +2942,7 @@ RELATION_THAN1_1
 <F_L str> = than
 =
 <F_L comp_temp1> += <F_R ref>
+
 #TemplateActionAlg
 RELATION_THAN1_2
 <LAB> = \C\.* 
@@ -2961,6 +2951,7 @@ RELATION_THAN1_2
 =
 <F_L comp_temp1> += <F_R temp1>
 <F_R temp1> = %
+
 #TemplateActionAlg
 RELATION_THAN1_3
 <LAB> = \MVt\.*
@@ -2968,6 +2959,7 @@ RELATION_THAN1_3
 =
 <F_L ref links than1> += <F_R comp_temp1>
 <F_R comp_temp1> = %
+
 ;
 ;END OF THAN AND THAN1
 ;
@@ -3001,6 +2993,7 @@ COMPARATIVE_OBJECT_FINAL
 <comparative-relation-word> = $prep_source
 <comparative-cvar> = $prep_obj
 =
+
 ;
 ; Send (copy) prep-links to links
 ;
@@ -3009,6 +3002,7 @@ PREP_TO_LINKS
 <ref prep-links> != %
 =
 <ref links> <= <ref prep-links>
+
 ;
 ; Extracting comparative relations from Non-equal-gradable sentences such as 
 ; "He is more/less intelligent than John"
@@ -3023,12 +3017,14 @@ MORE_OR_LESS1a
 <F_L str> = more|less|many|much|little|fewer
 =
 <F_R relWord-temp> += <F_L str>
+
 #TemplateActionAlg
 MORE_OR_LESS1b
 <LAB> = \MVm|\Om\.*|EBmm
 <F_R str> = more|less
 =
 <F_L relWord-temp> += <F_R str>
+
 #TemplateActionAlg
 ;e.g. I find maths lessons more enjoyable than science lessons.
 ;relAdj-temp creates the temp adjective for F_R of Opn connector
@@ -3036,6 +3032,7 @@ MORE_OR_LESS1c
 <LAB> = \Opn
 =
 <F_R relAdj-temp> += <F_L linkR1 F_R ref>
+
 ;SX is used to connect the first person pronoun "I" to the verbs "was" and "am".
 #TemplateActionAlg
 TO_BE_TEMP
@@ -3066,6 +3063,7 @@ MORE_OR_LESS7a_2
 <F_R ref links _comparative> += <F_L is-temp>
 <F_L is-temp> = %
 <F_R relWord-temp> = %
+
 #TemplateActionAlg
 MORE_OR_LESS7b
 <LAB> = \MVa|\Ou\.*|\Op
@@ -3074,6 +3072,7 @@ MORE_OR_LESS7b
 =
 <F_R ref links _comparative> += <F_L ref>
 <F_R relWord-temp> = %
+
 #TemplateActionAlg
 MORE_OR_LESS7c
 <LAB> = \Opn|\MVa|\Oun
@@ -3084,6 +3083,7 @@ MORE_OR_LESS7c
 <F_R ref links _comparative> += <F_L ref>
 <F_L relWord-temp> = %
 <F_L relWord-temp> = is_set
+
 #TemplateActionAlg
 MORE_OR_LESS7d
 <LAB> = \Om\.*
@@ -3091,6 +3091,7 @@ MORE_OR_LESS7d
 <F_R str> = more|many|much|less|little
 =
 <F_R ref links _comparative> += <F_L ref>
+
 ;e.g. I find maths lessons more enjoyable than science lessons.
 ;creating "_comparative(enjoyable, maths)" relationship
 #TemplateActionAlg
@@ -3103,6 +3104,7 @@ MORE_OR_LESS7e
 <F_R ref links _comparative> += <F_L relAdj-temp>
 <F_R relWord-temp> = %
 <F_L relAdj-temp> = %
+
 ;e.g. I find science more difficult than mathematics. _comparative(difficult, science)
 #TemplateActionAlg
 MORE_OR_LESS7f
@@ -3112,6 +3114,7 @@ MORE_OR_LESS7f
 =
 <F_R ref links _comparative> += <F_L ref>
 <F_R relWord-temp> = %
+
 ;Creating more() binary relationships when there is no "more" terms in the sentence
 ;A few other words can also perform the function of "more",marking a phrase as the left half of a comparative.
 ;Theseinclude adjectives such as "bigger" and adverbs such as "better" and "further".
@@ -3126,6 +3129,7 @@ MORE_OR_LESS7f1
 =
 <F_R ref links _comparative> += <F_L is-temp>
 <F_L is-temp> = %
+
 #TemplateActionAlg
 NO_MORE_OR_LESS
 <LAB> = \MVb
@@ -3534,10 +3538,6 @@ CLEAN_UP_BAD_REFS2
 ;<ref BAD> = T
 ;=
 ;<ref> = %
-;
-;
-;
-;
 ;
 ;/////////////////////////////////////////////////////////////////////////////
 ;/////////////////////////////// END OF FILE /////////////////////////////////

--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -1364,10 +1364,11 @@ PREP_X
 ;
 #TemplateActionAlg
 PREP_PHRASE
-<LAB> = \J\.*
+<LAB> = \J\.*|\ON\.*
 =
 <F_L obj> = <F_R head-word>
 <F_L ref links _pobj> += <F_L obj>
+
 ;
 #TemplateActionAlg
 DANGLING_PREP
@@ -1386,6 +1387,8 @@ PREP_ADJECTIVAL
 ;
 ; The exception in the rule below is for cases where an adverb intervenes
 ; between a verb and the prep-adv as in "He ran largely in the morning."
+; Note; I'm not sure there's any reason prepositional adverbials need their
+; own dependency as opposed to just being classified as adverbials . . .
 ;
 #TemplateActionAlg
 PREP_ADVERBIAL
@@ -1475,7 +1478,7 @@ APPOSITIVE_ADVERBIAL
 <F_L ref links _advmod> += <F_R ref>
 
 ;
-; The preposition modifies the following phrase
+; prepositional relative pronoun:
 ; "Jim, on whom we sat, cried."
 ; "The man on whom we sat cried."
 ;
@@ -1506,6 +1509,7 @@ PREP_RELATIVE_BACKGROUND
 <F_L background ref> += <F_R head-word ref>
 <F_L background wall> = <F_L wall>
 <F_L background BACKGROUND-FLAG> = T
+
 ;
 ; You are happy because you are here.
 ; Because you are here, you are happy.
@@ -1518,15 +1522,24 @@ PREP_RELATIVE_BACKGROUND
 ; Wont apply to "Often, we left" because 'often' has no obj
 ;
 
-#PrepositionLinkAlg
-PRECEEDING_PREP_LINK
-<LAB> = \CO\.*|\Qd\.*
-<F_L PREP-OBJ> = T
-<F_R head-word> = $modified
-<F_L str> = $prep
-<F_L> = $prep_source
-<F_L obj> = $prep_obj
+;
+; I can't figure out why this rule had a \Qd\ in the <LAB> condition,
+; so I deleted it . . .(AN Dec 2014)
+;
+#TemplateActionAlg
+OPENING_PREP_ADVERBIAL
+<LAB> = \CO\.*
+<F_L POS> = prep
 =
+<F_R head-word ref links _prepadv> = <F_L ref>
+
+#TemplateActionAlg
+OPENING_ADVERBIAL
+<LAB> = \CO\.*
+<F_L POS> != prep
+=
+<F_R head-word ref links _advmod> = <F_L ref>
+
 #PrepositionLinkAlg
 PREP_CLAUSE_OBJECT
 ; The preposition modifies the preceeding phrase

--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -1382,6 +1382,7 @@ PREP_ADJECTIVAL
 <LAB> = \Mp\.*|\Mj\.*|\MX\.*j|\MG\.*
 =
 <F_L ref links _prepadj> += <F_R ref>
+
 ;
 ; The exception in the rule below is for cases where an adverb intervenes
 ; between a verb and the prep-adv as in "He ran largely in the morning."
@@ -1473,17 +1474,28 @@ APPOSITIVE_ADVERBIAL
 =
 <F_L ref links _advmod> += <F_R ref>
 
-#PrepositionLinkAlg
+;
 ; The preposition modifies the following phrase
-;   "Jim, on whom we sat, cried."
-;   "The man on whom we sat cried."
-PREP_RELATIVE_LINK
-<LAB> = \Mj\.*|\MX.j\.*
-<F_R head-word> = $modified
-<F_R str> = $prep
-<F_R> = $prep_source
-<F_R obj> = $prep_obj
+; "Jim, on whom we sat, cried."
+; "The man on whom we sat cried."
+;
+#TemplateActionAlg
+INVERSE_RELATIVE_PREP
+<LAB> = \CV\.*
+<F_L POS> = prep
+<F_R POS> = verb
 =
+<F_R ref links _advmod> = <F_L ref>
+<INVERSE-REL-PREP FLAG> = T
+;
+; Delete the _prepadj relation for "The man on whom we sat."
+;
+#TemplateActionAlg
+DELETE_REL_PREPADJ
+<LAB> = \Mj\.*|\MX.j\.*
+=
+<F_L ref links _prepadj> = %
+
 ;
 #TemplateActionAlg
 ; Relative prepositions should have their modified phrases 

--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -1367,7 +1367,7 @@ PREP_PHRASE
 <LAB> = \J\.*
 =
 <F_L obj> = <F_R head-word>
-<F_L ref links _prep> += <F_L obj>
+<F_L ref links _pobj> += <F_L obj>
 ;
 #TemplateActionAlg
 DANGLING_PREP_LINK1
@@ -1375,7 +1375,7 @@ DANGLING_PREP_LINK1
 <F_L str> = who|Who|whom|Whom|what|What
 =
 <F_R obj> = <F_L head-word>
-<F_R ref links _prep> += <F_L obj>
+<F_R ref links _pobj> += <F_L obj>
 ;
 #TemplateActionAlg
 PREP_ADJECTIVAL
@@ -1384,15 +1384,18 @@ PREP_ADJECTIVAL
 <F_L ref links _prepadj> = <F_R ref>
 ;
 #TemplateActionAlg
-PREP_ADJECTIVAL
+PREP_ADVERBIAL
 <LAB> = \MVp\.*|\OF\.*|\LI\.*|\Pp\.*
 =
 <F_L ref links _prepadv> = <F_R ref>
 ;
-;
 ; NB!!! I suspect that virtually all of the preposition rules either already
 ; are or will be completely useless when I'm done writing new ones above this
 ; note but I'm not deleting any until I finish. (AN DEc 2014)
+;
+
+;
+; This is a misplaced question rule: "Where did John put it?"
 ;
 #TemplateActionAlg
 PREP_CLAUSE_LINKING_WHERE
@@ -1400,6 +1403,9 @@ PREP_CLAUSE_LINKING_WHERE
 <F_L ref QUERY-TYPE> = %
 =
 <F_L head-word> += <F_R>
+
+;
+; This is the misplaced 's posession rule: "This is John's wife."
 ;
 #TemplateActionAlg
 POSSR_TO_APOSTROPHE
@@ -1407,15 +1413,11 @@ POSSR_TO_APOSTROPHE
 =
 <F_R possessor> += <F_L ref>
 
-#TemplateActionAlg
-PREP_OBJ
-<LAB> = \MVa
-=
-<F_L prep-temp> += <F_R>
-
+;
 ;e.g. Mike runs as fast as he did last year.
 ;this forms "as(fast, he)" relationship
 ;CX is used in comparative constructions like "as I do"
+;
 #PrepositionLinkAlg
 PREP_LINKING
 <LAB> = \MVz\.*
@@ -1427,16 +1429,13 @@ PREP_LINKING
 <F_R linkR0 F_R subj> = $prep_obj
 =
 ;
-; The preposition modifies the preceeding phrase
+; Apparently MVi is reserved for (in order) to
 ;
-#PrepositionLinkAlg
-PREP_LINKING
+#TemplateActionAlg
+IN_ORDER_TO
 <LAB> = \MVi\.*
-<F_L> = $modified
-<F_R str> = $prep
-<F_R> = $prep_source
-<F_R to-do> = $prep_obj
 =
+<F_L ref links _goal> += <F_R head-word ref>
 
 #PrepositionLinkAlg
 ; The preposition modifies the following phrase
@@ -1957,6 +1956,7 @@ COMPARATIVE_Dmum
 ; Jim runs quickly.
 ; MVr: "She handled it quickly and gracefully."
 ; MVb: "He sang louder and stronger."
+
 #TemplateActionAlg
 ADV1
 <LAB> = \MVa\.*|\MVb\.*|\MVr\.*|\EB\.*
@@ -1967,6 +1967,7 @@ ADV1
 =
 <F_L head-word BACKGROUND-FLAG> = T
 <F_L head-word ref links _advmod> += <F_R ref>
+
 ;
 ; -------------------------------------------------------------
 ; Adverb usage in comparaitves

--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -1345,13 +1345,7 @@ TOBE_TO_LINKS
 ;
 ;  PREPOSITIONS
 ;
-;
-#TemplateActionAlg
-PREP_CLAUSE_LINKING_WHERE
-<LAB> = \WR\.*
-<F_L ref QUERY-TYPE> = %
-=
-<F_L head-word> += <F_R>
+;/////////////////////////////////////////////////////////////////////////////
 ;
 ; The rule below replaces the predeterminer with its object.
 ; Have to whack the existing object to do this.
@@ -1368,102 +1362,51 @@ PREP_X
 <F_R obj> = <F_R xobj>
 <F_R xobj> = %
 ;
-
-#PrepositionLinkAlg
-PREP_CLAUSE_LINKING
-; The preposition modifies the preceeding word with a clause
-; Fails if any of the template variables are not filled
-;
-;   "I see the building where Jim lives."
-;   "I feel like Jim feels."
-;
-; Don't include Pp in this list -- it generates garbage for:
-;   "The ball is under the couch" -- gets under(be,under)
-;
-; <LAB> = \Mp\.*|\MVp\.*|\MX.x\.*|\OF\.*|\MG\.*|\LI\.*|\Pp\.*
-<LAB> = \Mp\.*|\MVp\.*|\MX.x\.*|\OF\.*|\MG\.*|\LI\.*
-<F_R head-word> != %
-<F_L> = $modified
-<F_R str> = $prep
-<F_R> = $prep_source
-<F_R head-word ref> = $prep_obj
+#TemplateActionAlg
+PREP_PHRASE
+<LAB> = \J\.*
 =
-
-; The preposition modifies the preceeding word with a noun
-; Fails if any of the template variables are not filled
-
-#PrepositionLinkAlg
-PREP_LINKING
-;<LAB> = \Mp\.*|\MVp\.*|\MX.x\.*|\OF\.*|\MG\.*|\LI\.*|\Pp\.*
-<LAB> = \MX.x\.*|\OF\.*|\MG\.*|\LI\.*|\Pp\.*
-<F_R head-word> = %
-<F_L> = $modified
-<F_R str> = $prep
-<F_R> = $prep_source
-<F_R obj> = $prep_obj
+<F_L obj> = <F_R head-word>
+<F_L ref links _prep> += <F_L obj>
+;
+#TemplateActionAlg
+DANGLING_PREP_LINK1
+<LAB> = \B\.*
+<F_L str> = who|Who|whom|Whom|what|What
 =
-<F_R prep-parts _prepobj> = <F_R obj>
-<F_L prep-parts _prepsubj> = <F_R ref>
-
-; The alg below is designed just for dangling prepositions at the
-; end of ungrammatical questions: "Who did you give it to?" but it
-; doesn't work yet . . .
-;#PrepositionLinkAlg
-;DANGLING_PREP_LINK1
-;<LAB> = \B\.*
-;<F_R str> = to
-;<F_L str> = who|Who|whom|Whom|what|What
-;=
-;<F_R prep-parts prepobj> = _$qVar
-
+<F_R obj> = <F_L head-word>
+<F_R ref links _prep> += <F_L obj>
+;
+#TemplateActionAlg
+PREP_ADJECTIVAL
+<LAB> = \Mp\.*|\Mj\.*|\MX\.*j|\MG\.*
+=
+<F_L ref links _prepadj> = <F_R ref>
+;
+#TemplateActionAlg
+PREP_ADJECTIVAL
+<LAB> = \MVp\.*|\OF\.*|\LI\.*|\Pp\.*
+=
+<F_L ref links _prepadv> = <F_R ref>
+;
+;
+; NB!!! I suspect that virtually all of the preposition rules either already
+; are or will be completely useless when I'm done writing new ones above this
+; note but I'm not deleting any until I finish. (AN DEc 2014)
+;
+#TemplateActionAlg
+PREP_CLAUSE_LINKING_WHERE
+<LAB> = \WR\.*
+<F_L ref QUERY-TYPE> = %
+=
+<F_L head-word> += <F_R>
+;
 #TemplateActionAlg
 POSSR_TO_APOSTROPHE
 <LAB> = \YS\.* |\YP\.*
 =
 <F_R possessor> += <F_L ref>
-;
-; -----------------------------------------------------------
-; Why are there all these incomplete algorithms here? 10-22-2014 AN
-;------------------------------------------------------------
-;
-;\Mp --> e.g. Jack’s hair color is similar to that of Ben’s.
-;\MVp --> e.g. Amen's hair is as long as Ben's.
-#PrepositionLinkAlg
-PREP_LINKING
-<LAB> = \Mp\.*|\MVp\.*
-<F_R linkR0 LAB> = \J\.*
-<F_R linkR0 F_R possessor> != %
-<F_R head-word> = %
-<F_L> = $modified
-<F_R str> = $prep
-<F_R> = $prep_source
-<F_R linkR0 F_R possessor> = $prep_obj
-=
 
-#PrepositionLinkAlg
-PREP_LINKING
-<LAB> = \Mp\.*|\MVp\.*
-<F_R linkR0 LAB> = \J\.*
-<F_R linkR0 F_R possessor> = %
-<F_R head-word> = %
-<F_L> = $modified
-<F_R str> = $prep
-<F_R> = $prep_source
-<F_R obj> = $prep_obj
-=
-
-;e.g. The snail is running  exactly as fast as the cheetah.
-;this forms "as(run, cheetah)" relationship
-;"as.z" can form unconstrained phrases using "O*c+" just like "than" behaves.
-#PrepositionLinkAlg
-PREP_LINKING
-<LAB> = \MVz
-<F_R linkR0 LAB> = \O\.\c\.*
-<F_L> = $modified
-<F_R str> = $prep
-<F_R> = $prep_source
-<F_R linkR0 F_R ref> = $prep_obj
-=
 #TemplateActionAlg
 PREP_OBJ
 <LAB> = \MVa
@@ -1494,6 +1437,7 @@ PREP_LINKING
 <F_R> = $prep_source
 <F_R to-do> = $prep_obj
 =
+
 #PrepositionLinkAlg
 ; The preposition modifies the following phrase
 ;   "Jim, on whom we sat, cried."
@@ -1574,20 +1518,7 @@ PRECEEDING_PREP_CLAUSE_OBJECT
 ; This is used for "John is in the room" to change subj to psubj
 ; "The garage is next to the house".
 ; "The book is on the table."
-;
-#TemplateActionAlg
-SPECIAL_PREP_RULE
-<LAB> = \Pp\.*
-<F_L str> = be
-<F_R ref links _subj> != %
-<F_R ref links _obj> != %
-=
-<F_R ref SPECIAL-PREP-FLAG> = T
-<F_R ref links _psubj> = <F_R ref links _subj> 
-<F_R ref links _pobj> = <F_R ref links _obj>
-<F_R ref links _subj> = %
-<F_R ref links _obj> = %
-;
+
 #TemplateActionAlg
 CONJ_PREP_RULE
 <F_L ref links _pobj> != %
@@ -1650,6 +1581,7 @@ SPECIAL_PREP_RULE_WHEN_WHEN
 ;
 ; DT == time-related determiner e.g. next, every
 ;
+;////////////////////////////////////////////////////////////////////////////
 #TemplateActionAlg
 ADJ1
 <LAB> = \A\.*|\DT\.*|TQ

--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -887,12 +887,12 @@ WHEN
 ;
 ; Rule below not working, not sure why yet . . . 
 ;
-;#TemplateActionAlg
-;PREPWHEN
-;<LAB> = \D\.*
-;<F_L ref QUERY-TYPE> = when
-;=
-;<F_L head-question-word ref links _%atTime> = <F_L ref>
+#TemplateActionAlg
+PREPWHEN
+<LAB> = \D\.*
+<F_L ref QUERY-TYPE> = when
+=
+<F_L head-question-word ref links _%atTime> = <F_L ref>
 ;
 #TemplateActionAlg
 ; This algoritm was modified to exclude cases where there isn't a todo 
@@ -997,6 +997,12 @@ HOW_ADV
 <F_L str> = how
 =
 <F_R head-word ref links _advmod> += <F_R ref>
+#TemplateActionAlg
+HOW_ADJ
+<LAB> = \EAh
+<F_L str> = how
+=
+<F_R ref links _predadj> += <F_R head-word subj>
 ;
 ; SPECIAL RULE FOR DO-Questions: "What did Ben do?" "What did Ben want
 ; to do?" Prevents "do" from having an object.  Instead, turns the head

--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -1549,7 +1549,7 @@ OPENING_ADVERBIAL
 ;
 #TemplateActionAlg
 COMP_PHRASE
-<LAB> = \C\.*
+<LAB> = \C\.*|\Mg\.*
 <F_L POS> != verb|adj
 =
 <F_L ref links _comp> += <F_R head-word ref> 
@@ -1564,7 +1564,7 @@ OMITTED_THAT_COMP
 #TemplateActionAlg
 COMP_MOD
 <LAB> = \MVs
-<F_R str> != because|since|considering|when
+<F_R str> != because|when|while
 =
 <F_L ref links _compmod> += <F_R ref>
 
@@ -1586,7 +1586,7 @@ REP_COMP
 ;
 #TemplateActionAlg
 WHEN_COMP
-<LAB> = \WN\.*|\MVs
+<LAB> = \WN\.*|\MVs\.*
 <F_R str> = when|while
 =
 <F_L ref linke _%atTime> += <F_R ref>
@@ -1594,7 +1594,7 @@ WHEN_COMP
 #TemplateActionAlg
 BECAUSE_COMP
 <LAB> = \MVs
-<F_R str> = because|since
+<F_R str> = because
 =
 <F_L ref links _%because> += <F_R ref>
 

--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -1485,7 +1485,7 @@ INVERSE_RELATIVE_PREP
 <F_L POS> = prep
 <F_R POS> = verb
 =
-<F_R ref links _advmod> = <F_L ref>
+<F_R ref links _prepadv> = <F_L ref>
 <INVERSE-REL-PREP FLAG> = T
 ;
 ; Delete the _prepadj relation for "The man on whom we sat."

--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -1370,7 +1370,7 @@ PREP_PHRASE
 <F_L ref links _pobj> += <F_L obj>
 ;
 #TemplateActionAlg
-DANGLING_PREP_LINK1
+DANGLING_PREP
 <LAB> = \B\.*
 <F_L str> = who|Who|whom|Whom|what|What
 =
@@ -1381,13 +1381,30 @@ DANGLING_PREP_LINK1
 PREP_ADJECTIVAL
 <LAB> = \Mp\.*|\Mj\.*|\MX\.*j|\MG\.*
 =
-<F_L ref links _prepadj> = <F_R ref>
+<F_L ref links _prepadj> += <F_R ref>
+;
+; The exception in the rule below is for cases where an adverb intervenes
+; between a verb and the prep-adv as in "He ran largely in the morning."
 ;
 #TemplateActionAlg
 PREP_ADVERBIAL
 <LAB> = \MVp\.*|\OF\.*|\LI\.*|\Pp\.*
+<F_L POS> != adv
 =
-<F_L ref links _prepadv> = <F_R ref>
+<F_L ref links _prepadv> += <F_R ref>
+
+;
+; This is supposes to create the advmod of a prep by any adverbial
+; but it doesn't do anything for some reason . . .
+;
+#TemplateActionAlg
+ADVMOD_OF_ADVERBIAL
+<LAB> = \MVp\.*|\MVa\.*|\MVs\.*
+<F_L> POS> = adv
+=
+<F_R ref links _advmod> += <F_L ref>
+<F_L modified> += <F_R ref>
+
 ;
 ; NB!!! I suspect that virtually all of the preposition rules either already
 ; are or will be completely useless when I'm done writing new ones above this
@@ -1436,6 +1453,25 @@ IN_ORDER_TO
 <LAB> = \MVi\.*
 =
 <F_L ref links _goal> += <F_R head-word ref>
+
+;
+; For cases such as "He did it largely in his spare time" 
+; to make prepadv(do, in) -- not working yet.
+;
+#TemplateActionAlg
+ADVERB_OBSTRUCTED_PREPADV
+<LAB> = \MVl\.*
+=
+<F_L ref links _prepadv> += <F_R modified>
+
+;
+; John left, carrying a dog.
+;
+#TemplateActionAlg
+APPOSITIVE_ADVERBIAL
+<LAB> = \MVx\.*|\MVg\.*
+=
+<F_L ref links _advmod> += <F_R ref>
 
 #PrepositionLinkAlg
 ; The preposition modifies the following phrase

--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -1173,17 +1173,7 @@ THAT1
 =
 <F_L that> += <F_R head-word ref>
 ;
-;
-#TemplateActionAlg
-THAT_TO_LINKS
-; 'that' is handled in preposition section. (PREP_CLAUSE_OBJECT)
-<str> != %
-<str> != that
-<that> != %
-=
-<ref links _that> = <that>
-;
-;
+
 #TemplateActionAlg
 RELATIVE_CLAUSE_TO_BACKGROUND
 <LAB> = \R\.*
@@ -1385,6 +1375,13 @@ PREP_ADJECTIVAL
 =
 <F_L ref links _prepadj> += <F_R ref>
 
+#TemplateActionAlg
+PARTICIPIAL_ADJECTIVAL
+<LAB> = \Mg\.*
+<F_L POS> != conjunction
+=
+<F_L ref links _amod> += <F_R ref>
+
 ;
 ; The exception in the rule below is for cases where an adverb intervenes
 ; between a verb and the prep-adv as in "He ran largely in the morning."
@@ -1396,7 +1393,7 @@ PREP_ADVERBIAL
 <LAB> = \MVp\.*|\OF\.*|\LI\.*|\Pp\.*
 <F_L POS> != adv
 =
-<F_L ref links _prepadv> += <F_R ref>
+<F_L ref links _advmod> += <F_R ref>
 
 ;
 ; This is supposes to create the advmod of a prep by any adverbial
@@ -1461,13 +1458,23 @@ IN_ORDER_TO
 
 ;
 ; For cases such as "He did it largely in his spare time" 
-; to make prepadv(do, in) -- not working yet.
+; to make advmod(do, in) -- not working yet.
 ;
+
+#TemplateActionAlg
+ADVMOD_OF_PREP
+<LAB> = \MVp\.*
+<F_L POS> = adv
+<F_R POS> = prep
+=
+<F_R ref links _advmod> += <F_L ref>
+<F_L modified> = <F_R ref>
+
 #TemplateActionAlg
 ADVERB_OBSTRUCTED_PREPADV
 <LAB> = \MVl\.*
 =
-<F_L ref links _prepadv> += <F_R modified>
+<F_L ref links _advmod> += <F_R modified>
 
 ;
 ; John left, carrying a dog.
@@ -1489,7 +1496,7 @@ INVERSE_RELATIVE_PREP
 <F_L POS> = prep
 <F_R POS> = verb
 =
-<F_R ref links _prepadv> = <F_L ref>
+<F_R ref links _advmod> = <F_L ref>
 <INVERSE-REL-PREP FLAG> = T
 ;
 ; Delete the _prepadj relation for "The man on whom we sat."
@@ -1527,14 +1534,6 @@ PREP_RELATIVE_BACKGROUND
 #TemplateActionAlg
 OPENING_PREP_ADVERBIAL
 <LAB> = \CO\.*
-<F_L POS> = prep
-=
-<F_R head-word ref links _prepadv> += <F_L ref>
-
-#TemplateActionAlg
-OPENING_ADVERBIAL
-<LAB> = \CO\.*
-<F_L POS> != prep
 =
 <F_R head-word ref links _advmod> += <F_L ref>
 
@@ -1550,7 +1549,7 @@ OPENING_ADVERBIAL
 #TemplateActionAlg
 COMP_PHRASE
 <LAB> = \C\.*|\Mg\.*
-<F_L POS> != verb|adj
+<F_L POS> != verb|adj|noun
 =
 <F_L ref links _comp> += <F_R head-word ref> 
 
@@ -1710,14 +1709,15 @@ ADJ1
 ;
 ; MVp usually modifies verbs, i.e. so its indicates an adverb.
 ; should probably check the POS on the left word to confirm.
+;
 #TemplateActionAlg
 ADJ2_1
-; <LAB> = \Mp\.*|\MVp\.*|\Ma\.*
-<LAB> = \Mp\.*
+<LAB> = \Mp\.*|\Ma\.*
 <F_R PREP-OBJ> = %
 =
 <F_L BACKGROUND-FLAG> = T
 <F_L ref links _amod> += <F_R ref>
+
 ;differentiate forming "_amod()" relationships when connected with "Ma" links
 ;e.g. I find maths lessons more enjoyable than science lessons. vs I find maths more difficult than science.
 ;in the fist sentence it does have a _amod() relationship but it doesn't in 2nd sentence.
@@ -3386,10 +3386,10 @@ HYP-TO-BE
 <_to-be HYP> = T
 ;
 #TemplateActionAlg
-HYP-THAT
-<_that> != %
+HYP-REP
+<_rep> != %
 =
-<_that HYP> = T
+<_rep HYP> = T
 ;
 #TemplateActionAlg
 HYP-THAT2

--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -1600,7 +1600,7 @@ BECAUSE_COMP
 ;
 ; I can't see how this rule handled anything not handled by the
 ; rules above that I just wrote, but I'm not sure, so I'm not
-; deleting it yet . . .
+; deleting it yet . . .(AN Dec 2014)
 ;
 ;#PrepositionLinkAlg
 ;PREP_CLAUSE_OBJECT2
@@ -1614,78 +1614,40 @@ BECAUSE_COMP
 ;=
 ;
 
-#PrepositionLinkAlg
-PRECEEDING_PREP_CLAUSE_OBJECT
-; The preposition modifies the following phrase
-<LAB> = \CO..\.*
-<F_R head-word> = $modified
-<F_L str> = $prep
-<F_L> = $prep_source
-<F_L head-word ref> = $prep_obj
-=
 ;
+; These rules have nothing to do with prepositons, 
+; but I found their previous versions in this section
+; so I revised them here (AN Dec 2014).
 ;
-; NOTE special prep rule is not working when the prep is modified: 
-;    "Mike is in the room on Tuesday..."
-; This is used for "John is in the room" to change subj to psubj
-; "The garage is next to the house".
-; "The book is on the table."
 
 #TemplateActionAlg
-CONJ_PREP_RULE
-<F_L ref links _pobj> != %
-<F_R conj> != %
-=
-<F_L ref links _pobj> = %
-<F_L ref links _pobj> += <F_R conj member0 ref>
-<F_L ref links _pobj> += <F_R conj member1 ref>
-;
-#TemplateActionAlg
-SPECIAL_PREP_RULE_WHERE
+PREPOSED_PREDICATE_WHERE
 <LAB> = \PF\.*
 <F_L str> = where
 =
-<F_L ref name> = %
-<F_L ref name> = _%atLocation
+<F_R subj links _%atLocation> = <F_L ref>
+
 #TemplateActionAlg
-SPECIAL_PREP_RULE_WHEN
+PREPOSED_PREDICATE_WHEN
 <LAB> = \PF\.*
 <F_L str> = when
 =
-<F_L ref name> = %
-<F_L ref name> = _%atTime
-;
-; Example: "Where is the ball?"
-;
+<F_R subj links _%atTime> = <F_L ref>
+
 #TemplateActionAlg
-SPECIAL_PREP_RULE_WHERE_WHERE
+PREPOSED_PREDICATE_HOW
 <LAB> = \PF\.*
-<F_L str> = where
+<F_L str> = how
 =
-<F_L ref SPECIAL-PREP-FLAG> = T
-<F_L ref links _psubj> = <F_R ref links _subj>
-<F_R ref links _subj> = %
-<F_L ref links _pobj name> = _$qVar
-<F_L ref links _pobj nameSource> = %
-<F_L ref links _pobj nameSource> = <F_L>
-<F_L ref links _pobj QUERY-TYPE> = where
-<F_L ref tense> = <F_R ref tense>
-<F_L head-word> = <F_L>
-;
+<F_R subj links _%how> = <F_L ref>
+
 #TemplateActionAlg
-SPECIAL_PREP_RULE_WHEN_WHEN
+PREPOSED_PREDICATE_ADJECTIVAL
 <LAB> = \PF\.*
-<F_L str> = when
+<F_L str> != where|when|how
 =
-<F_L ref SPECIAL-PREP-FLAG> = T
-<F_L ref links _psubj> = <F_R ref links _subj>
-<F_R ref links _subj> = %
-<F_L ref links _pobj name> = _$qVar
-<F_L ref links _pobj nameSource> = %
-<F_L ref links _pobj nameSource> = <F_L>
-<F_L ref links _pobj QUERY-TYPE> = when
-<F_L ref tense> = <F_R ref tense>
-<F_L head-word> = <F_L>
+<F_R subj links _predadj> = <F_L ref>
+
 ;
 ;/////////////////////////////////////////////////////////////////////////////
 ;

--- a/data/relex-semantic.algs
+++ b/data/relex-semantic.algs
@@ -48,6 +48,7 @@ CONJ_AND_LEFT_MULTI
 <F_L str> = and|or|but|,
 =
 <F_R conj> += <F_L linkR1 F_R>
+
 #TemplateActionAlg
 CONJ_AND_RIGHT_MULTI
 <LAB> = \AJr\.*|\MJr\.*|\QJr\.*|\RJr\.*|\SJr\.*|\VJr\.*
@@ -72,7 +73,7 @@ FIND_PREDET
 <LAB> = \AL\.*
 <F_L linkR1 LAB> = \J\.*
 =
-<F_L predet> = <F_L linkR1 F_R ref>
+<F_L quantity> = <F_L linkR1 F_R ref>
 ;
 ; The below is is needed to get propositions correct.
 ; We have to stick the predet ref into the reference so it can be found.
@@ -94,6 +95,7 @@ FIND_PREDET_FOR_PREPS
 ; No subject for SF (filler subject) aka "expletive"
 ; Also exclude some relative constructions
 ; no conjunctions
+
 #TemplateActionAlg
 STANDARD_SUBJ
 <LAB> = \S\.*|\SX\.*|\MX\.*
@@ -117,27 +119,38 @@ MAKE_STANDARD_SUBJ
 ;
 #TemplateActionAlg
 SUBJ_PREDET
-<F_L predet> != %
+<F_L quantity> != %
 <F_R subj> != %
 =
 <F_R subj> = %
-<F_R subj> = <F_L predet>
+<F_R subj> = <F_L quantity>
 
-;
-;
 ;
 ; Same as above, but the subject link pointed to a conjunction.
 ; Create a _subj for each conjoined subject.
 ; Example: "Apples and bananas are delicious."
+
+#TemplateActionAlg
+CONJUNCTION_MEMBER0
+<LAB> = \SJl\.*|\AJl\.*|\RJl\.*
+=
+<F_R conj-member0> += <F_L ref>
+
+#TemplateActionAlg
+CONJUNCTION_MEMBER1
+<LAB> = \SJrs|\AJr\.*|\RJr\.*
+=
+<F_L conj-member1> += <F_R ref>
+
 #TemplateActionAlg
 CONJ_STANDARD_SUBJ
 <IS_SUBJ_LINK> = T
 <F_L conj> != %
 =
 <F_R CONJ_SUBJ> = T
-<F_R subj> += <F_L conj member0 ref>
-<F_R subj> += <F_L conj member1 ref>
-;
+<F_R subj> += <F_L conj-member0>
+<F_R subj> += <F_L conj-member1>
+
 ;
 ; Same as above, but the subject link pointed to a conjunction.
 ; Create a _subj for each conjoined subject.
@@ -149,7 +162,7 @@ COMPLEX_CONJ_STANDARD_SUBJ
 <F_L linkL1 LAB> = \SJl\.*
 <F_L linkL1 F_L conj> != %
 =
-<F_R subj> += <F_L linkL1 F_L conj member0 ref>
+<F_R subj> += <F_L linkL1 F_L conj-member0>
 ;
 ; Inverted version of standard subject.
 #TemplateActionAlg
@@ -237,14 +250,15 @@ DIR_OBJ_N
 =
 <F_L OBJ-LINK-TAG> = O-n
 <F_L obj> += <F_R ref>
-;
-; #TemplateActionAlg
-; DIR_OBJ2
-; <LAB> = \O\.n\.*
-; <LAB> != \O\.i\.*
-; <F_L OBJ-LINK-TAG> != O-n|UNSET
-; =
-; <F_L obj> += <F_R ref>
+
+;#TemplateActionAlg
+;DIR_OBJ2
+;<LAB> = \O\.n\.*
+;<LAB> != \O\.i\.*
+;<F_L OBJ-LINK-TAG> != O-n|UNSET
+;=
+;<F_L obj> += <F_R ref>
+
 ;
 #TemplateActionAlg
 GER_OBJ
@@ -289,6 +303,7 @@ WHATQ_OBJ
 ; Case- <F_R linkL1 LAB> != \Dmum --> e.g. avoid relationship of 
 ;       _obj(earn, money), sentence "He earns much more money than I do."  
 ; O*c+ connects comparatives
+
 #TemplateActionAlg
 DIR_OBJ1
 <LAB> = \O\.*|\OD\.*|\OT\.*
@@ -296,25 +311,10 @@ DIR_OBJ1
 <LAB> != \O\.n\.*
 <LAB> != \O\.i\.*
 <LAB> != Omm | Om
+<F_L linkL0 LAB> != \B\.*
 ;<F_R linkL1 LAB> != Dmum
 <F_L OBJ-LINK-TAG> = O|UNSET
-=
-<F_L OBJ-LINK-TAG> = O
-<F_L obj> += <F_R ref>
-;
-;e.g. "He runs more than John." This sentence produces two parse 
-; trees that have exactly the same cost. 
-; i.e. (run, more) connected through Omm AND MVm. 
-; So one can argue it forms a _obj(run, more) relationship and above
-; rule DIR_OBJ1 avoids that.
-; So when <LAB> = \Omm | \Om occurs this rule applies to form object
-; relationships. 
-;
-#TemplateActionAlg
-DIR_OBJ1_1
-<LAB> = Omm | Om
-<F_L linkR0 LAB> = MVt
-<F_L OBJ-LINK-TAG> = O|UNSET
+<F_L linkR0 LAB> != \IV|\TO\.*
 =
 <F_L OBJ-LINK-TAG> = O
 <F_L obj> += <F_R ref>
@@ -332,6 +332,12 @@ DIR_OBJ1_1
 <F_L obj> = %
 <F_L obj> = <F_R linkR0 F_R ref>
 
+#TemplateActionAlg
+DIROBJ_Osm
+<LAB> = \O\.*\.m
+=
+<F_L ref links _obj> += <F_R ref>
+
 ;
 ;START BUG 3 Solution #################################
 ;   "I want you to eat cake."
@@ -346,6 +352,7 @@ ALG1
 <LAB> = Ox
 =
 <F_L temp1> += <F_R ref>
+
 #TemplateActionAlg
 ALG2
 <LAB> = \TO\.*
@@ -399,6 +406,15 @@ REL_OBJ
 =
 <F_R OBJ-LINK-TAG> = B
 <F_R obj> += <F_L ref>
+
+#TemplateActionAlg
+DIROBJ_Ox
+<LAB> = Ox
+<F_L obj> = %
+<F_L linkR0 LAB> != IV|\TO\.*
+=
+<F_L obj> += <F_R ref>
+
 ;
 #TemplateActionAlg
 REL_INDIR_OBJ
@@ -418,6 +434,15 @@ REL_INDIR_OBJ
 <F_R OBJ-LINK-TAG> != BW
 =
 <F_R iobj> += <F_L ref>
+
+#TemplateActionAlg
+REL_INDIR_OBJ2
+<LAB> = \O\.*
+<F_L obj> != %
+<F_L obj> != <F_R ref>
+=
+<F_L iobj> = <F_R ref>
+
 ;
 ; Conjunction fixups for object. Basically, we don't want obj
 ; pointing at the conjunction, we want it pointing at the actual things.
@@ -427,10 +452,20 @@ CONJ_OBJ
 <F_R conj> != %
 <F_R POS> = conjunction
 <LAB> != \VJ\.*
+<F_L POS> != prep
 =
 <F_L obj> = %
-<F_L obj> += <F_R conj member0 ref>
-<F_L obj> += <F_R conj member1 ref>
+<F_L obj> += <F_R conj-member0>
+<F_L obj> += <F_R conj-member1>
+
+#TemplateActionAlg
+PREP_CONJ_OBJ
+<LAB> = \Ju
+=
+<F_L ref links _obj> = %
+<F_L ref links _pobj> += <F_R conj-member0>
+<F_L ref links _pobj> += <F_R conj-member1>
+
 ;
 ;Example: Scientists make observations and ask questions.
 #TemplateActionAlg
@@ -480,12 +515,12 @@ SUBJECT_LINKING
 ;
 ;"So \Pg can be removed here? "
 ;
-<LAB> = \Pg\.*|\Pp\.*|\PP\.*|\I\.*
+<LAB> = \Pg\.*|\PP\.*|\I\.*
 ;<LAB> = \Pp\.*|\PP\.*|\I\.*
 <F_L obj> = %
 <F_L FILLER-OBJ-FLAG> != T
 =
-<F_R subj> = <F_L subj>
+<F_R subj> += <F_L subj>
 <F_L subj> = %
 ;
 #TemplateActionAlg
@@ -535,7 +570,7 @@ PREDADJ_PREDET
 <F_L predet> != %
 <F_R subj links _predadj> != %
 =
-<F_R subj links _predadj> = <F_L predet>
+<F_R subj links _predadj> = <F_L quantity>
 ;
 ;
 ; If the Pa object is a conjunction, then create a _predadj for
@@ -556,6 +591,7 @@ PREDADJ_LINKING_CONJOIN
 ; predictive adjective for comparatives
 ; e.g. Jack is more/less ingenious than Ben is crazy. 
 ; _predadj(Ben, crazy) plus we dont need _subj(is,Ben)
+
 #TemplateActionAlg
 PREDICATIVE_comparatives1
 <LAB> = \Paf
@@ -628,12 +664,6 @@ OBJECT_LINKING_TO
 <F_L ADJ-OBJ-FLAG> = %
 =
 <F_R subj> = <F_L obj>
-;
-#TemplateActionAlg
-PREP_OBJ
-<PREP-OBJ-LINK-FLAG> = T
-=
-<F_L obj> += <F_R ref>
 ;
 ;/////////////////////////////////////////////////////////////////////////////
 ;
@@ -780,6 +810,28 @@ HEAD_TO_CLAUSE_AND_WALL
 =
 <F_L head-word> += <F_R head-word>
 ;
+
+#TemplateActionAlg
+NOUN_PHRASE_HEAD_WORD
+<LAB> = \D\.*
+<F_R head-word> = %
+=
+<F_R head-word> = <F_R ref>
+
+#TemplateActionAlg
+DETERMINER_HEAD_WORD
+<LAB> = \D\.*
+<F_L head-word> = %
+=
+<F_L head-word> = <F_R head-word>
+
+#TemplateActionAlg
+QUANTITY_HEAD_WORD
+<LAB> = \AL\.*
+<F_L head-word> = %
+=
+<F_L head-word> = <F_R head-word>
+
 #TemplateActionAlg
 PROPOGATE_HEAD-WORD
 <tense first_verb head-word> = $Z
@@ -1245,9 +1297,17 @@ TODO1z
 <LAB> != Pg*b
 <F_R TO-BE-FLAG> != T
 <F_R head-word> != %
+<F_L str> != can|could|will|would|may|might|must|need|can't|couldn't|won't|wouldn't|mustn't|needn't
 =
 <F_L to-do> += <F_R head-word ref>
-;
+
+#TemplateActionAlg
+MODAL_AUXILLIARIES
+<LAB> = \I\.*|\Pg\.*
+<LAB> != Pg*b
+<F_L str> = can|could|will|would|may|might|must|need|can't|couldn't|won't|wouldn't|mustn't|needn't
+=
+<F_L ref links _modal> += <F_R head-word ref>
 ;
 #TemplateActionAlg
 TODO2
@@ -1354,6 +1414,20 @@ TOBE_TO_LINKS
 ; Example: "Joan thanked Susan for all the help she had given."
 ; We want to get for(thank, help) not for(thank, all)
 ;
+
+#TemplateActionAlg
+COMPLEX_PREPOSTION_CONSTRUCTION
+<LAB> = \Ju
+<F_R POS> = conjunction
+=
+<F_L ref links conj_prep> += <F_R ref>
+
+#TemplateActionAlg
+SO_THAT_STRUCTURE
+<LAB> = \EExk
+=
+<F_L str> = so_that
+
 #TemplateActionAlg
 PREP_X
 <LAB> = \Mp\.*|\MVp\.*|\MX.x\.*|\OF\.*|\MG\.*|\LI\.*|\Pp\.*
@@ -1364,21 +1438,57 @@ PREP_X
 <F_R obj> = <F_R xobj>
 <F_R xobj> = %
 ;
+;This is just to handle cases where the prepositional complement
+;does not yet have a head-word, in preparation for the next alg
 #TemplateActionAlg
-PREP_PHRASE
+PREP_PHRASE_HEADWORD
 <LAB> = \J\.*|\ON\.*|\MG\.*|\Mgp
-<F_L POS> = prep
+<F_R head-word> = %
 =
-<F_L obj> = <F_R head-word>
-<F_L ref links _pobj> += <F_L obj>
+<F_R head-word> = <F_R ref>
 
+#TemplateActionAlg
+PREP_OBJECT
+<LAB> = \J\.*|\ON\.*|\MG\.*|\Mgp
+<F_L str> != all
+=
+<F_L ref links _pobj> += <F_R head-word>
+
+#TemplateActionAlg
+PREP_SUBJECT_FLAG
+<LAB> = \Pp
+=
+<F_L PREP-SUBJ-FLAG> = T
+
+#TemplateActionAlg
+PREP_SUBJECT_STORE
+<LAB> = \S\.*
+<LAB> != \S\.*\.*\.t
+<F_R PREP-SUBJ-FLAG> = T
+=
+<F_R psubj> = <F_L ref>
+
+#TemplateActionAlg
+PREP_SUBJ_ASSIGN
+<LAB> = \Pp
+=
+<F_R ref links _psubj> += <F_L psubj>
+<F_L psubj> = %
+<F_L PREP-SUBJ-FLAG> = %
+
+;This is a pretty strange way to regard these structures by my ken,
+;but probably the easiest thing to work within the current 'grammar'
+;of Relex (AN)
+
+;I believe the reason this akg is not doing anything is the POS clause
+; but I don't know why it doesn't work.
 ;
 #TemplateActionAlg
 DANGLING_PREP
 <LAB> = \B\.*
 <F_L str> = who|Who|whom|Whom|what|What
+<F_R POS> = prep
 =
-<F_R obj> = <F_L head-word>
 <F_R ref links _pobj> += <F_L ref>
 ;
 #TemplateActionAlg
@@ -1402,7 +1512,7 @@ PARTICIPIAL_ADJECTIVAL
 
 #TemplateActionAlg
 EQUATIVE_COMPARATIVE_FIRST_DEGREE
-<LAB> = \EEy\.*
+<LAB> = \EEy\.*|\EAy\.*
 =
 <F_R COMPARED_MOD_FLAG> = T
 <F_R BACKGROUND-FLAG> = T
@@ -1426,16 +1536,27 @@ COMPARATIVE_SECOND_CONTEXT
 <F_L linkL0 F_L linkR2 F_R ref links _compcontadv2> += <F_R linkR0 F_R ref>
 <F_L COMPCONT_FLAG> = T
 
-;
-; The exception in the rule below is for cases where an adverb intervenes
-; between a verb and the prep-adv as in "He ran largely in the morning."
-; Note; I'm not sure there's any reason prepositional adverbials need their
-; own dependency as opposed to just being classified as adverbials . . .
-;
+#TemplateActionAlg
+ADVMOD_N
+<LAB> = \MVp\.*|\MVa\.*|\MVs\.
+<F_L POS> = verb
+=
+<F_L ref links _advmod> += <F_R ref>
+<F_R modified> += <F_L ref>
+
+#TemplateActionAlg
+ADVMOD_OF_ADERBIAL
+<LAB> = \MVp\.*
+<F_L POS> != verb
+=
+<F_R ref links _advmod> += <F_L ref>
+<F_L modified> += <F_R ref>
+
 #TemplateActionAlg
 PREP_ADVERBIAL
-<LAB> = \MVp\.*|\OF\.*|\LI\.*|\Pp\.*
+<LAB> = \MVp\.*|\OF\.*|\LI\.*
 <F_L POS> != adv
+<F_L modified> = %
 <F_R COMPCONT_FLAG> !=T
 <F_L COMPCONT_FLAG> !=T
 =
@@ -1447,17 +1568,6 @@ IMPLICIT_COMPARED_MOD
 =
 <F_R ref links _advmod> += <F_L linkL0 F_L ref links _advmod>
 
-;
-; This is supposes to create the advmod of a prep by any adverbial
-; but it doesn't do anything for some reason . . .
-;
-#TemplateActionAlg
-ADVMOD_OF_ADVERBIAL
-<LAB> = \MVp\.*|\MVa\.*|\MVs\.*
-<F_L> POS> = adv
-=
-<F_R ref links _advmod> += <F_L ref>
-<F_L modified> += <F_R ref>
 
 ;
 ; This is a misplaced question rule: "Where did John put it?"
@@ -1467,7 +1577,7 @@ PREP_CLAUSE_LINKING_WHERE
 <LAB> = \WR\.*
 <F_L ref QUERY-TYPE> = %
 =
-<F_L head-word> += <F_R>
+<F_L head-word> += <F_R ref>
 
 ;
 ; This is the misplaced 's posession rule: "This is John's wife."
@@ -1493,15 +1603,6 @@ IN_ORDER_TO
 ;
 
 #TemplateActionAlg
-ADVMOD_OF_PREP
-<LAB> = \MVp\.*
-<F_L POS> = adv
-<F_R POS> = prep
-=
-<F_R ref links _advmod> += <F_L ref>
-<F_L modified> += <F_R ref>
-
-#TemplateActionAlg
 ADVERB_OBSTRUCTED_PREPADV
 <LAB> = \MVl\.*
 =
@@ -1515,6 +1616,20 @@ APPOSITIVE_ADVERBIAL
 <LAB> = \MVx\.*|\MVg\.*
 =
 <F_L ref links _advmod> += <F_R ref>
+
+; (AN JAN 2015) This next one seems like an LG error; for "He ran so quickly that 
+; he flew." LG has 'that . . .' modifying 'ran' as an adverbial whereas I think that
+; it should be modifying 'quickly'; it tells you HOW quickly. And so X that Y, works the
+; same way if X is an adjective.  If LG gtets corrected, you can simplify the alg . . .
+; (This algorithm seems not to be running; I don't know why).
+
+#TemplateActionAlg
+SO_THAT_ADVERBIAL
+<LAB> = \MVh\.*
+<F_L linkR0 LAB> = \MVa\.*|\Ma\.*
+=
+<F_L linkR0 F_R ref links _%howdeg> += so_that
+<F_R str> = so_that
 
 ;
 ; prepositional relative pronoun:
@@ -1572,47 +1687,88 @@ OPENING_PREP_ADVERBIAL
 ;
 ; The following series of algs create some complement phrases
 ; and hook them up to the things they modify, picking out some
-; which already have more speciic relations, -- because, when,
-; and introducing rep() for 'representation' as in 'I think that . . .'
+; which already have more speciic relations, -- relative clauses
+; are distinguished from because and when, and other complements.
+; And introducing rep() for 'representation' as in 'I think that . . .'
 ; these really aren't all related stuff, but they were all previously
 ; conflated in one rule in this section, so they get revised here . . .
 ; (AN Dec 2014)
 ;
-#TemplateActionAlg
-COMP_PHRASE
-<LAB> = \C\.*|\Mg\.*
-<F_L POS> != verb|adj|noun
-=
-<F_L ref links _comp> += <F_R head-word ref> 
-
-#TemplateActionAlg
-OMITTED_THAT_COMP
-<LAB> = \Ce\.*
-<F_L POS> = verb|adj
-=
-<F_L ref links _rep> += <F_R head-word ref>
-
-#TemplateActionAlg
-COMP_MOD
-<LAB> = \MVs
-<F_R str> != because|when|while
-=
-<F_L ref links _compmod> += <F_R ref>
-
-;
 ; _rep is the relation of representing something,
-; mentally or verbally; it requires a unique relation
+; mentally, verbally, or otherwise. It requires a unique relation
 ; because it affects the inferences that can be made
 ; about the content within its scope.
 ; 
 #TemplateActionAlg
-REP_COMP
+Relative-cause
+<LAB> = \R\.*
+<LAB> != \Rw
+=
+<F_L ref links _relmod> += <F_R ref> 
+
+#TemplateActionAlg
+Relativizer
+<LAB> = \RS\.*
+<LAB> != \RSe\.*
+=
+<F_L ref links _rel> += <F_R head-word ref> 
+
+#TemplateActionAlg
+RELATIVE_CLAUSE_PHRASE
+<LAB> = \C\.*|\Mg\.*
+<LAB> !=\Ce\.*
+<F_L POS> != verb|adj|noun
+<F_L str> != as
+=
+<F_L ref links _rel> += <F_R head-word ref> 
+
+#TemplateActionAlg
+THAT_REP_COMP
 <LAB> = \TH\.*|
 =
 <F_L ref links _rep> += <F_R ref>
+<F_R REP_FLAG> = T
+
+#TemplateActionAlg
+OMITTED_THAT_REP
+<LAB> = \Ce\.*|\RSe\.*
+<F_L POS> = verb|adj
+=
+<F_L ref links _rep> += <F_R head-word ref>
+<F_L REP_FLAG> = T
+
+#TemplateActionAlg
+COMP_MOD
+<LAB> = \MVs
+<F_R str> != because|when|while|as
+=
+<F_L ref links _compmod> += <F_R ref>
 
 ;
-; So far, can't find a sentence that uses this link --
+; The below is for "The dog who Jack said chased me" -- a combination
+; of "the dog who chased me" (relative) and "Jack said the dog chased me"
+; (representation)
+;
+#TemplateActionAlg
+RELATIVE_CLAUSE_PLUS_REP
+<LAB> = \CV
+<F_L linkL0 F_L ref links _relmod> != %
+<F_R ref links _rep> != %
+=
+<F_L ref links _rel> += <F_R ref links _rep>
+
+#TemplateActionAlg
+OTHER_COMP_CLAUSE
+<LAB> = \CV
+; only call it a 'complement' if it's not already assigned as a relative clause
+; or a 'rep' (sentential complement to a mental, verbal, or logical predicate)
+<F_L ref links _rel> = %
+<F_R ref links _rep> = %
+=
+<F_L ref links _comp> += <F_R ref>
+
+;
+; So far, can't find a sentence that uses this LG link --
 ; maybe the dictionary documentation is outdated . . .
 ;
 #TemplateActionAlg
@@ -1657,21 +1813,21 @@ PREPOSED_PREDICATE_WHERE
 <LAB> = \PF\.*
 <F_L str> = where
 =
-<F_R subj links _%atLocation> = <F_L ref>
+<F_R subj links _%atLocation> += <F_L ref>
 
 #TemplateActionAlg
 PREPOSED_PREDICATE_WHEN
 <LAB> = \PF\.*
 <F_L str> = when
 =
-<F_R subj links _%atTime> = <F_L ref>
+<F_R subj links _%atTime> += <F_L ref>
 
 #TemplateActionAlg
 PREPOSED_PREDICATE_HOW
 <LAB> = \PF\.*
 <F_L str> = how
 =
-<F_R subj links _%how> = <F_L ref>
+<F_R subj links _%how> += <F_L ref>
 
 #TemplateActionAlg
 PREPOSED_PREDICATE_ADJECTIVAL
@@ -1694,6 +1850,8 @@ ADJ1
 =
 <F_R BACKGROUND-FLAG> = T
 <F_R ref links _amod> += <F_L ref>
+<F_R ref links _amod> += <F_L conj-member0>
+<F_R ref links _amod> += <F_L conj-member1>
 
 ;
 ; Treat preps without objects as adjectives -- copula (Pp) is treated
@@ -1736,7 +1894,7 @@ ADJ3
 <F_L linkL0 F_L ref links _amod> += <F_R ref>
 ;
 ; Predeterminer
-; All the boys are here. - _predet(boy, all)
+; All the boys are here. - _quantity(boy, all)
 ;
 #TemplateActionAlg
 PREDET
@@ -1744,7 +1902,7 @@ PREDET
 <F_L linkR1 LAB> = \J\.*
 ; <F_L linkR1 LAB> = Jp
 =
-<F_L linkR1 F_R ref links _predet> = <F_L ref> 
+<F_L linkR1 F_R ref links _quantity> = <F_L ref> 
 
 ; For sentences like "I want aisle seats on all my flights"
 #TemplateActionAlg
@@ -1752,25 +1910,17 @@ PREDET2
 <LAB> = \AL\.*
 <F_L linkR0 LAB> = \J\.*
 =
-<F_L linkR0 F_R ref links _predet> = <F_L ref> 
+<F_L linkR0 F_R ref links _quantity> = <F_L ref> 
 
 ;/////////////////////////////////////////////////////////////////////////////
 ; Rules  for handling Extrapositions
 ;/////////////////////////////////////////////////////////////////////////////
 ;
-; ---------------------------------------------------------------
-; who, whose constructions
-;
-; Example: "The woman who lives next door is a nurse."
-;
-#TemplateActionAlg
-Adjective-clause-who-1
-<LAB> = \B\.*
-<F_L linkR2 F_R str> = who
-<F_R str> != be|has
-=
-<F_L ref links who> += <F_R ref> 
-
+; This section has just undergone wholesale revision, and most of the relevant
+; material is now back in the preosition section, bynecessity because of stuff
+; that was incorrectly placed back there when I found it.  When I finish fixing
+; all of this, I will try to finish the re-organization and put headers on it
+; (AN Jan 2015)
 ;
 ; Example: ... ???
 ;
@@ -1792,26 +1942,25 @@ Adjective-clause-whose-2
 <F_L ref links whose> += <F_R linkR1 F_R ref> 
 
 ;
-; Example: Alana Bishop, who hosted the party, is my cousin.
-;
-#TemplateActionAlg
-Adjective-clause-who-3
-<LAB> = \RS.*
-<F_L str> = who
-<F_R str> = be|has
-=
-<F_L linkL0 F_L ref links who> += <F_R linkR0 F_R ref>
-
-;
 ;Example: Bob, whose name is in that book, is the student near the window. 
+; (I have changed this from what it was before in a strange way, which I think
+; will best work with R2L -- I have implied that 'whose' is a preposition here!
+; It is not :) but 'the book whose author . . .' means 'the book of the author who . . . '
+; so this is the most consistent way to treat it.  I didn't want to use _poss b/c
+; this construction can be used in other ways such as 'the man whose deeds . . .' (AN 1/2015)).
 ;
 #TemplateActionAlg
-Adjective-clause-whose-4
+Adjective-clause-whose-4a
 <LAB> = \D\.*
 <F_L linkL0 LAB> = \Mr\.*
-<F_L str> = whose
 =
-<F_L linkL0 F_L ref links whose> += <F_R ref>
+<F_L ref links _pobj> += <F_R ref>
+
+#TemplateActionAlg
+Adjective-clause-whose-4b
+<LAB> = \Mr\.*
+=
+<F_L ref links _det> += <F_R ref>
 
 ; ---------------------------------------------------------------
 ; that/which constructions.
@@ -1820,60 +1969,26 @@ Adjective-clause-whose-4
 ; For example, "He is glad that she won." which uses a TH link to "that".
 ; The rules below take care of various relative clauses that don't use
 ; the TH connector.
-
+;
+;(AN Jan 2015) -- I just deleted a bunch of stuff here which was crazy wrong.
+; The 'that' in 'he is glad that she
+; won' plays a completely different grammatical and semantic role than the
+; 'that' in 'They ate a curry that was recommended'; the first one introduces
+; a proposition towards which the subject has an attitude, and is subject
+; to logical opacity; it refers to a representation, not reality. Whereas
+; the second 'that' is more simply, just a way to modify the noun it follows
+; with a phrase serving the same function as an adjective -- an adjectival
+; complement.  And there's no reason to limit it to clauses with main verb
+; 'to be'; you can also say "They ate the curry that Bill cooked." What is
+; needed are two algorithms -- one to establish modification of the noun
+; or adjective by the adjectival clause, and another to attach the adjectival
+; clause to its complement (who, which, or that).  I have provided the new
+; correct algorithms, but they are back in the preposition section because
+; that is where previous coders had placed certain algorithms that they 
+; need to precede.
+;
 ; Example: They ate a special curry which was recommended by the restaurant’s owner. 
 ;
-#TemplateActionAlg
-Adjective-clause-which-1
-<LAB> = RS
-<F_R linkR0 LAB> = \P\.*
-<F_L str> = which 
-<F_R str> = be|has
-=
-<F_L linkL0 F_L ref links which> += <F_R linkR0 F_R ref> 
-
-;
-; Identical to above, except this uses "that" insted of "which".
-;
-#TemplateActionAlg
-Adjective-clause-THAT-1
-<LAB> = RS
-<F_R linkR0 LAB> = \P\.*
-<F_L str> = that
-<F_R str> = be|has
-=
-<F_L linkL0 F_L ref links that> += <F_R linkR0 F_R ref> 
-
-;-------
-;
-; Example: Andrew stopped the police car that was driving fast.
-; Example: Just before the crossroads, the car was stopped by a traffic sign which stood on the street.
-; Example: The books which I read in the library were written by Charles Dickens. 
-; Example: The restaurant which belongs to my aunt is very famous.
-; 
-#TemplateActionAlg
-Adjective-clause-which-2
-<LAB> = RS | CV
-<F_L str> = which
-<F_R str> != be|has
-=
-<F_L linkL0 F_L ref links which> += <F_R ref>
-;
-;
-; Identical to the above, except this allows "that" instead of "which".
-; Example: He is glad that she won.
-; Example: The book that she lent me is very boring.
-; Example: Just before the crossroads, the car was stopped by a traffic sign that stood on the street.
-; Example: The books that I read in the library were written by Charles Dickens. 
-; Example: The restaurant that belongs to my aunt is very famous.
-;
-#TemplateActionAlg
-Adjective-clause-THAT-2
-<LAB> = RS | CV
-<F_L str> = that
-<F_R str> != be|has
-=
-<F_L linkL0 F_L ref links that> += <F_R ref>
 
 ;--------
 ;
@@ -1934,8 +2049,8 @@ CONJ_AMOD
 ;<LAB> != \SJr\.*
 =
 <F_R ref links _amod> = %
-<F_R ref links _amod> += <F_L conj member0 ref>
-<F_R ref links _amod> += <F_L conj member1 ref>
+<F_R ref links _amod> += <F_L conj-member0>
+<F_R ref links _amod> += <F_L conj-member1>
 
 #TemplateActionAlg
 CONJ_PREDADJ
@@ -1945,8 +2060,8 @@ CONJ_PREDADJ
 <LAB> != \VJ\.*|\AJ\.*|\SJ\.*|\MJ\.*|\RJ\.*
 =
 <F_L subj links _predadj> = %
-<F_L subj links _predadj> += <F_R conj member0 ref>
-<F_L subj links _predadj> += <F_R conj member1 ref>
+<F_L subj links _predadj> += <F_R conj-member0>
+<F_L subj links _predadj> += <F_R conj-member1>
 ;
 ;/////////////////////////////////////////////////////////////////////////////
 ; COMPARATIVES of various kinds.
@@ -1972,11 +2087,38 @@ CONJ_PREDADJ
 ;In this case, the connector between "more/less" and "enjoyable" is specially
 ;subscripted with "EAm" (the special subscript "m") to handle such "more/less" cases.
 
+; (AN Jan 2015) The following two algs do a pretty strange thing.  The issue is that
+; in "He eats more pizza than John" we ould like to know that John eats pizza, but in
+; in "He eats more pizza than veggies" we would like to know that he eats veggies, but
+; there is no way to differentiate the two within LG, so I have decided to create a 
+; comp_arg() relation, which means that it is a subject or object of comparison. At least
+; PLN will have that to work with.
+
 #TemplateActionAlg
-COMPARATIVE_ONE
+COMPARATIVE_ARGUMENT_ID
+<LAB> = \O\.*\.c
+=
+<F_L comp_arg> = <F_R ref>
+
+#TemplateActionAlg
+COMPARATIVE_ARGUMENT_LINK
+<LAB> = \MVt\.*
+=
+<F_L ref links comp_arg> += <F_R comp_arg>
+
+#TemplateActionAlg
+COMPARATIVE_DEGREE
 <LAB> = \EEm\.*|\EAm\.*
 =
 <F_R ref links _compdeg> += <F_L ref>
+<F_R ref degree> = comparative
+
+#TemplateActionAlg
+COMPARATIVE_AMOUNT
+<LAB> = \Dm\.*m
+=
+<F_R ref links _compamt> += <F_L ref>
+<F_R ref degree> = comparative
 
 ;e.g. He is more/less intelligent than attractive.
 ;the connector between "more/less" and "is" is specially
@@ -1986,7 +2128,8 @@ COMPARATIVE_TWO
 <LAB> = \Pa\.*|\MVt
 <F_L linkR1 LAB> = \EBmm|\Omm|\Om\MVm
 =
-<F_R ref links _compdeg> = <F_L linkR1 F_R ref>
+<F_R ref links _compdeg> += <F_L linkR1 F_R ref>
+<F_R ref degree> = comparative
 
 ;He did it more/less quickly than carefully.
 ;e.g - He runs more/less quickly than John does.
@@ -1999,17 +2142,34 @@ COMPARATIVE_THREE
 =
 <F_R ref links _compdeg> = <F_L linkR2 F_R ref>
 
+#TemplateActionAlg
+COMPARATIVE_MVp-Om
+<LAB> = \MVp
+<F_L linkR2 LAB> = \Omm | \Om
+=
+<F_L linkR2 F_R ref degree> = comparative
+
 ;
 ;Here "more" is serving as a noun-phrase, the number of the noun in the "more" phrase is
 ;indicated by the D link ( it should be either noun-phrase  or as determiner of
 ;a noun ); if it is a "Dmum", the noun is
 ;singular, whereas if it is "Dmcm", the noun is plural.
 ;Here it forms the degree relationship of the noun-phrase
+
+; This rule needs more conditions in order not to over-apply
+; so I am commmenting it out temporarily . . .
+; #TemplateActionAlg
+; QUANTITY
+; <LAB> = \Jp\.*
+; =
+; <F_R ref links _quantity> += <F_L ref>
+
 #TemplateActionAlg
-QUANTITY
-<LAB> = \Dm\.*
+COMPARATIVE_Dmum
+<LAB> = \Dmcm | \Dmum
+<F_L str> = more|much|less|fewer
 =
-<F_R ref links _quantity> = <F_L ref>
+<F_L ref degree> = comparative
 
 ;
 ;/////////////////////////////////////////////////////////////////////////////
@@ -2039,9 +2199,31 @@ ADV1
 <F_L COMPCONT_FLAG> != T
 =
 <F_L head-word BACKGROUND-FLAG> = T
-<F_L head-word ref links _advmod> += <F_R ref>
+<F_L head-word advmod> += <F_R ref>
+<F_L ref links _advmod> += <F_R conj-member0>
+<F_L ref links _advmod> += <F_R conj-member1>
 
-;
+; ------------------------------------------------------------- 	
+; Adverb usage in comparaitves 	
+; 	
+;e.g. He runs less quickly than John does. 	
+;Above ADV1 rule only makes _advmod(run, quickly) but we want to make infer that he 	
+;runs (quickly,less) 	
+;Following rule make the binary relationship _advmod(quickly, less) 	
+;Note- The above example sentence is ungrammatical. 	
+;But sentence is commonly used by non-native English speakers. 	
+;So below rule is adding support for common, ungrammatical sentences. 	
+#TemplateActionAlg
+ADV1_1
+<LAB> = \MVa
+<F_R str> != not|more|less
+<F_L head-word> != %
+<F_R degree> = %
+<F_L linkR2 F_R str> = more|less
+=
+<F_R ref links _compdeg> += <F_L linkR2 F_R ref>
+
+
 ;e.g. He runs faster than John.
 ;Above ADV1 rule won't make _advmod(run, fast) relationship due to "faster" is 
 ;POS tagged with ".a-c" and relex-tagging.algs make it's degree as comparative.
@@ -2049,12 +2231,15 @@ ADV1
 
 #TemplateActionAlg
 ADV1_2
-<LAB> = \MVb\.*
-<F_R str> != not|more|less|often
-<F_R degree> != %
+<LAB> = \MVb
 =
-<F_L head-word BACKGROUND-FLAG> = T
-<F_R ref links _compdeg> += more
+<F_L ref links _advmod> += <F_R ref>
+
+#TemplateActionAlg
+COMPARATIVE_ER_TO_MORE
+<subscript> = \.a-c
+=
+<ref links _compdeg> += more
 
 ;
 ; MVp : "find elsewhere" e.g.  "... than you can find elsewhere."
@@ -2082,10 +2267,12 @@ ADV1_ONLY_IF_NOT_PREP
 ;
 ; Jim quickly runs.
 ; Jim is very tired.
+
 #TemplateActionAlg
 ADV2
 <LAB> = \E\.*|\EA\.*
-<LAB> != \Eq\.*|\EA[my]\.*|\EAh
+<LAB> != \Eq\.*|\EA[my]\.*|\EAh|\EAy
+<F_L str> != more|less|fewer
 <F_R head-word ref> != %
 =
 <F_R head-word BACKGROUND-FLAG> = T
@@ -2100,6 +2287,7 @@ ADV2
 ADV2_HEADLESS
 <LAB> = \E\.*|\EA\.*
 <LAB> != \Eq\.*|\EA[my]\.*|\EAh
+<F_L str> != more|less|fewer
 <F_R head-word ref> = %
 =
 <F_R BACKGROUND-FLAG> = T
@@ -2111,12 +2299,18 @@ ADV2_HEADLESS
 ;which is the reason to omits "y" subscripts here
 ;He is as smart		EAy+
 ;He runs as quickly	EEy+
-;
+
+#TemplateActionAlg
+SO_THAT_STRUCTURE
+<LAB> = \EExk
+=
+<F_L str> = so_that
+
 #TemplateActionAlg
 ADV3
 <LAB> = \EE\.* | EA
-<LAB> != \EEy | \EAy|\EEh |\EAh
-<F_L str> != more
+<LAB> != \EEy|\EAy|\EEh|\EAh|\EExk
+<F_L str> != more|less
 =
 <F_R BACKGROUND-FLAG> = T
 <F_R ref links _advmod> += <F_L ref>
@@ -2128,14 +2322,24 @@ ADV3
 ;which is the reason to omits "y" subscripts here
 ;He is as smart		EAy+
 ;He runs as quickly	EEy+
+
 #TemplateActionAlg
 ADV3_1
 <LAB> = \EE\.*
-<LAB> != \EEy|\EEh
+<LAB> != \EEy|\EEh|\EExk|\EAy
 <F_R linkL0 LAB> = \MVa
+<F_L str> != more|less|fewer
 =
 <F_R BACKGROUND-FLAG> = T
 <F_R ref links _advmod> += <F_L ref>
+
+#TemplateActionAlg
+SO_THAT_ADV
+<LAB> = \EExk
+=
+<F_R BACKGROUND-FLAG> = T
+<F_R ref links _advmod> += <F_L ref>
+<F_L ref links _compmod> += <F_R linkL0 F_L linkR0 F_R ref>
 
 ; The below is added to handle the how in 'how-of-degree questions' as in 'how quickly does he run'
 ; which were previously being picked up by the rules above and pre-empting the r2l advmod rule; 
@@ -2175,6 +2379,15 @@ CONJ_ADVMOD
 <F_L ref links _advmod> += <F_R conj member0 ref>
 <F_L ref links _advmod> += <F_R conj member1 ref>
 
+#TemplateActionAlg
+COMP_ADVMOD_1_1
+<LAB> = \EBmm|\MVm|\EAm|\Om
+<F_R str> = less | more
+=
+<F_L ref links _compdeg> += <F_R ref>
+
+;EC connects adverbs and comparative adjectives 
+;ECn is used for noun-focused comparative
 ;EC connects adjectives and adverbs with comparative adverbs
 ;e.g. It is much bigger
 #TemplateActionAlg
@@ -2202,12 +2415,14 @@ COMP_ADVMOD_2_2
 <F_R ref links _advmod> += <F_L advmod>
 <F_L advmod> = %
 
-#TemplateActionAlg
-COMP_ADVMOD_3
-<LAB> = \EAm
-<F_L str> = less|more
-=
-<F_R advmod> += <F_L ref>
+;this has been replaced by _compdeg.  Just commenting it out for
+;the moment in case all is not well, then I can bring it back (AN Jan 2015)
+;#TemplateActionAlg
+;COMP_ADVMOD_3
+;<LAB> = \EAm
+;<F_L str> = less|more
+;=
+;<F_R advmod> += <F_L ref>
 
 ;case "<F_L str> != much" was introduced to form relationships such as _advmod(more, much)
 ;e.g. My sister is much more intelligent than me. 
@@ -2392,6 +2607,7 @@ NUMBER-1
 <LAB> = \D\.*|\NW\.*
 <LAB> != \D..y
 <LAB> != \Dmcn
+<F_L str> != whose
 <F_L DETERMINER_FLAG> != T
 <F_L QUERY_INDEFINATE_DETERMINER_FLAG> != T
 <F_L POSSESSIVE-FLAG> != T
@@ -2443,10 +2659,9 @@ NUMBER-NUMERIC-QUANTIFIERS
 NUMBER-1a
 ;<LAB> = \ND\.*|\NI\.*
 <LAB> = \ND\.*
-<F_L QUANTITY-EXCEPTION-FLAG> != T
-<F_R linkR0 LAB> = \Dmcm|\Dmum
+<F_R str> != am|pm|AM|PM|o'clock
 =
-<F_R linkR0 F_R ref links _quantity> = <F_L ref>
+<F_R ref links _quantity> += <F_L ref>
 <F_L IS-NUMBER-FLAG> = T
 <F_R NOT_NUMBER_FLAG> = T
 
@@ -3011,6 +3226,7 @@ PREP_TO_LINKS
 ; feat-temp = a temporary element carrying the feature on which the comparison is made on.
 ; is-temp = a temporary element carrying the subject for to-be verbs
 ; "is_set" =  used to point that a comparative form has been found and set 
+
 #TemplateActionAlg
 MORE_OR_LESS1a
 <LAB> = \EAm|\EEm|\Dm\.*m
@@ -3065,13 +3281,28 @@ MORE_OR_LESS7a_2
 <F_R relWord-temp> = %
 
 #TemplateActionAlg
-MORE_OR_LESS7b
-<LAB> = \MVa|\Ou\.*|\Op
+MORE_OR_LESS7b1
+<LAB> = \MVa|\Ou\.*
 <F_R relWord-temp> != %
 <F_R relWord-temp> = more|many|much|less|little|fewer
 =
-<F_R ref links _comparative> += <F_L ref>
+<F_L ref links _comparative> += <F_R ref>
 <F_R relWord-temp> = %
+
+#TemplateActionAlg
+MORE_OR_LESS7b2
+<LAB> = \Op\.*
+<F_L relWord-temp> = more|many|much|less|little|fewer
+=
+<F_L ref links _comparative> += <F_R ref>
+
+#TemplateActionAlg
+MORE_OR_LESS7b3
+<LAB> = \Op\.*
+<F_R relWord-temp> = more|many|much|less|little|fewer
+=
+<F_L ref links _comparative> += <F_R ref>
+
 
 #TemplateActionAlg
 MORE_OR_LESS7c
@@ -3080,7 +3311,7 @@ MORE_OR_LESS7c
 <F_R str> != much
 <F_L relWord-temp> = more|many|much|less|little
 =
-<F_R ref links _comparative> += <F_L ref>
+<F_L ref links _comparative> += <F_R ref>
 <F_L relWord-temp> = %
 <F_L relWord-temp> = is_set
 
@@ -3090,7 +3321,7 @@ MORE_OR_LESS7d
 <F_L relWord-temp> != is_set
 <F_R str> = more|many|much|less|little
 =
-<F_R ref links _comparative> += <F_L ref>
+<F_L ref links _comparative> += <F_R ref>
 
 ;e.g. I find maths lessons more enjoyable than science lessons.
 ;creating "_comparative(enjoyable, maths)" relationship
@@ -3135,7 +3366,21 @@ NO_MORE_OR_LESS
 <LAB> = \MVb
 <F_R degree> = comparative
 =
-<F_R ref links _comparative> += <F_L ref>
+<F_L ref links _comparative> += <F_R ref>
+
+#TemplateActionAlg
+NO_MODIFIERa
+<LAB> = \MVm
+<F_L relWord-temp> = %
+=
+<F_L ref links _comparative> += <F_R ref>
+
+;#TemplateActionAlg
+;NO_MODIFIERb
+;<LAB> = \MVm
+;<F_L relWord-temp> != %
+;=
+;<F_L ref links _comparative> += <F_L relWord-temp>
 
 ;
 ;/////////////////////////////////////////////////////////////////////////////

--- a/data/relex-tagging.algs
+++ b/data/relex-tagging.algs
@@ -48,7 +48,7 @@ SUBSCR_POS_A
 SUBSCR_POS_A-C
 <subscript> = .a-c
 =
-<POS> = adj
+<POS> = adj|adv
 <degree> = comparative
 
 ; Superlative adjectives
@@ -56,7 +56,7 @@ SUBSCR_POS_A-C
 SUBSCR_POS_A-S
 <subscript> = .a-s
 =
-<POS> = adj
+<POS> = adj|adv
 <degree> = superlative
 
 ; b == both -- male or female given name.
@@ -1222,9 +1222,9 @@ COMBINE_PREP_QWORD
 #TemplateActionAlg
 PREPQUESTION1
 <LAB> = \D\.*
-<F_L prephead> = at|in|to|from|around
-<F_L str> = what|which|where
-<F_R str> = place|location|area|region
+<F_L prephead> = at|in|to|from|around|near|by
+<F_L str> = what|which
+<F_R POS> = place|location|area|region
 =
 <F_L ref name> = _$qVar
 <F_L ref QUERY-TYPE> = where
@@ -1233,8 +1233,8 @@ PREPQUESTION1
 PREPQUESTION2
 <LAB> = \D\.*
 <F_L prephead> = at|by|on|around
-<F_L str> = what|which|when
-<F_R str> = time|date|day|moment|instant
+<F_L str> = what|which
+<F_R str> = time|date|day|moment|instant|hour
 =
 <F_L ref name> = _$qVar
 <F_L ref QUERY-TYPE> = when

--- a/data/relex2logic-rules.txt
+++ b/data/relex2logic-rules.txt
@@ -96,11 +96,11 @@
 
 [ADVMOD] {4} <> _advmod($V, $ADV) => (advmod-rule $V (get-instance-name $V word_index sentence_index) $ADV (get-instance-name $ADV word_index sentence_index))
 
-[ADVERBIALPP] {4} <> _prep($prep, $noun) & _prepadv($verb, $prep) => (advmod-rule $verb (get-instance-name $verb word_index sentence_index) $prep (get-instance-name $prep word_index sentence_index))
+[ADVERBIALPP] {4} <> _pobj($prep, $noun) & _prepadv($verb, $prep) => (advmod-rule $verb (get-instance-name $verb word_index sentence_index) $prep (get-instance-name $prep word_index sentence_index))
 
-[ADJECTIVALPP] {4} <> _prep($prep, $noun) & _prepadj($noun, $prep) => (amod-rule $noun (get-instance-name $noun word_index sentence_index) $prep (get-instance-name $prep word_index sentence_index))
+[ADJECTIVALPP] {4} <> _pobj($prep, $noun) & _prepadj($noun, $prep) => (amod-rule $noun (get-instance-name $noun word_index sentence_index) $prep (get-instance-name $prep word_index sentence_index))
 
-[PP] {4} <> _prep($prep, $noun) => (pp-rule $prep (get-instance-name $prep word_index sentence_index) $noun (get-instance-name $noun word_index sentence_index))
+[PP] {4} <> _pobj($prep, $noun) => (pp-rule $prep (get-instance-name $prep word_index sentence_index) $noun (get-instance-name $noun word_index sentence_index))
 
 # ============================================
 # unary rules

--- a/data/relex2logic-rules.txt
+++ b/data/relex2logic-rules.txt
@@ -102,6 +102,16 @@
 
 [PP] {4} <> _pobj($prep, $noun) => (pp-rule $prep (get-instance-name $prep word_index sentence_index) $noun (get-instance-name $noun word_index sentence_index))
 
+[COMPLEMENT_PHRASES] {4} <> _comp($comp, $pred) => (complement_rule $comp (get-instance-name $comp word_index sentence_index) $pred (get-instance-name $pred word_index sentence_index))
+
+[COMPlEMENT_RELATION] {4} <> _compmod($pred, $comp) => (compmod_rule $comp (get-instance-name $comp word_index sentence_index) $pred (get-instance-name $pred word_index sentence_index))
+
+[COMPlEMENT_BECAUSE] {4} <> _%because($pred, $comp) => (because_rule $comp (get-instance-name $comp word_index sentence_index) $pred (get-instance-name $pred word_index sentence_index))
+
+[COMPlEMENT_ATTIME] {4} <> _%atTime($pred, $comp) => (attime_rule $comp (get-instance-name $comp word_index sentence_index) $pred (get-instance-name $pred word_index sentence_index))
+
+[COMPlEMENT_REP] {4} <> _rep($pred, $comp) => (rep_rule $comp (get-instance-name $comp word_index sentence_index) $pred (get-instance-name $pred word_index sentence_index))
+
 # ============================================
 # unary rules
 # ============================================
@@ -176,7 +186,6 @@
 
 [PASSIVE2] {1} <PASSIVE1> _obj($A,$B) & tense($A, (.*)passive) => (passive-rule2 $A (get-instance-name $A word_index sentence_index) $B (get-instance-name $B word_index sentence_index))
 
-
 # ============================================
 # conjunction rules
 # ============================================
@@ -198,7 +207,6 @@
 # general that-rule works for any pos
 [THAT1] {110} <THAT-EXCL-1, THAT-EXCL-2> that($A, $B) => (that-rule $A (get-instance-name $A word_index sentence_index) $B (get-instance-name $B word_index sentence_index))
 [THAT2] {110} <THAT-EXCL-1, THAT-EXCL-2> _that($A, $B) => (that-rule $A (get-instance-name $A word_index sentence_index) $B (get-instance-name $B word_index sentence_index))
-
 
 # ============================================
 # time rules for dealing with temporal expressions

--- a/data/relex2logic-rules.txt
+++ b/data/relex2logic-rules.txt
@@ -15,7 +15,7 @@
 
 [SVIO2] {2} <SV, SVO> _subj($verb, $subj) & _obj($verb, $obj) & _obj(to, $iobj) => (SVIO-rule $subj (get-instance-name $subj word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj word_index sentence_index ) $iobj (get-instance-name $iobj word_index sentence_index))
 
-[SVIO3] {2} <SVO, SV> _subj($verb, $subj) & _obj($verb, $obj) & to($verb, $iobj) => (SVIO-rule $subj (get-instance-name $subj word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj word_index sentence_index ) $iobj (get-instance-name $iobj word_index sentence_index))
+[SVIO3] {2} <SVO, SV> _subj($verb, $subj) & _obj($verb, $obj) & _advmod($verb, $prep) & _pobj($prep, $iobj) => (SVIO-rule $subj (get-instance-name $subj word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj word_index sentence_index ) $iobj (get-instance-name $iobj word_index sentence_index))
 
 [SVO] {3} <SV, SVIO1, SVIO2, SVIO3, BE, whichobjQ, whichsubjQ> _subj($verb, $subj) & _obj($verb, $obj) => (SVO-rule $subj (get-instance-name $subj word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj word_index sentence_index))
 

--- a/data/relex2logic-rules.txt
+++ b/data/relex2logic-rules.txt
@@ -102,15 +102,15 @@
 
 [PP] {4} <> _pobj($prep, $noun) => (pp-rule $prep (get-instance-name $prep word_index sentence_index) $noun (get-instance-name $noun word_index sentence_index))
 
-[COMPLEMENT_PHRASES] {4} <> _comp($comp, $pred) => (complement_rule $comp (get-instance-name $comp word_index sentence_index) $pred (get-instance-name $pred word_index sentence_index))
+[COMPLEMENT_PHRASES] {4} <> _comp($comp, $pred) => (complement-rule $comp (get-instance-name $comp word_index sentence_index) $pred (get-instance-name $pred word_index sentence_index))
 
-[COMPlEMENT_RELATION] {4} <> _compmod($pred, $comp) => (compmod_rule $comp (get-instance-name $comp word_index sentence_index) $pred (get-instance-name $pred word_index sentence_index))
+[COMPlEMENT_RELATION] {4} <> _compmod($pred, $comp) => (compmod-rule $comp (get-instance-name $comp word_index sentence_index) $pred (get-instance-name $pred word_index sentence_index))
 
-[COMPlEMENT_BECAUSE] {4} <> _%because($pred, $comp) => (because_rule $comp (get-instance-name $comp word_index sentence_index) $pred (get-instance-name $pred word_index sentence_index))
+[COMPlEMENT_BECAUSE] {4} <> _%because($pred, $comp) => (because-rule $comp (get-instance-name $comp word_index sentence_index) $pred (get-instance-name $pred word_index sentence_index))
 
-[COMPlEMENT_ATTIME] {4} <> _%atTime($pred, $comp) => (attime_rule $comp (get-instance-name $comp word_index sentence_index) $pred (get-instance-name $pred word_index sentence_index))
+[COMPlEMENT_ATTIME] {4} <> _%atTime($pred, $comp) => (attime-rule $comp (get-instance-name $comp word_index sentence_index) $pred (get-instance-name $pred word_index sentence_index))
 
-[COMPlEMENT_REP] {4} <> _rep($pred, $comp) => (rep_rule $comp (get-instance-name $comp word_index sentence_index) $pred (get-instance-name $pred word_index sentence_index))
+[COMPlEMENT_REP] {4} <> _rep($pred, $comp) => (rep-rule $comp (get-instance-name $comp word_index sentence_index) $pred (get-instance-name $pred word_index sentence_index))
 
 # ============================================
 # unary rules

--- a/data/relex2logic-rules.txt
+++ b/data/relex2logic-rules.txt
@@ -96,7 +96,7 @@
 
 [ADVMOD] {4} <> _advmod($V, $ADV) => (advmod-rule $V (get-instance-name $V word_index sentence_index) $ADV (get-instance-name $ADV word_index sentence_index))
 
-[ADVERBIALPP] {4} <> _pobj($prep, $noun) & _prepadv($verb, $prep) => (advmod-rule $verb (get-instance-name $verb word_index sentence_index) $prep (get-instance-name $prep word_index sentence_index))
+[ADVERBIALPP] {4} <> _pobj($prep, $noun) & _advmod($verb, $prep) => (advmod-rule $verb (get-instance-name $verb word_index sentence_index) $prep (get-instance-name $prep word_index sentence_index))
 
 [ADJECTIVALPP] {4} <> _pobj($prep, $noun) & _prepadj($noun, $prep) => (amod-rule $noun (get-instance-name $noun word_index sentence_index) $prep (get-instance-name $prep word_index sentence_index))
 
@@ -178,7 +178,6 @@
 
 [ALLRULE2] {1} <> _predet($noun, all) => (all-rule (get-instance-name $noun word_index sentence_index))
 
-
 # ============================================
 # passive verb rules
 # ============================================
@@ -214,92 +213,4 @@
 [BEFORE] {100} <> before($subj, $verb) & pos($verb, $verb_pos) => (before-after-rule (get-instance-name $subj word_index sentence_index) (get-instance-name $verb word_index sentence_index) $verb_pos "before")
 [AFTER] {100} <> after($subj, $verb) & pos($verb, $verb_pos) => (before-after-rule (get-instance-name $subj word_index sentence_index) (get-instance-name $verb word_index sentence_index) $verb_pos "after")
 [TIME] {100} <> _time($period, $hour) & at($verb, $period) => (time-rule $hour $period (get-instance-name $verb word_index sentence_index))
-
-# ===================================================
-# Old redundant but functional question rules
-# ===================================================
-#[prepobj-YNQ] {1} <SV> TRUTH-QUERY-FLAG($verb, T) & _psubj($verb, $subj) & _pobj($verb, $obj) => (prepobj-ynQ-rule $subj (get-instance-name $subj word_index sentence_index) 
-#$verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj word_index sentence_index))
-#[SVIO-ynQ] {1} <SVO-ynQ, SV-ynQ, SVIO, SVO> TRUTH-QUERY-FLAG($verb|$obj, T) & _subj($verb, $subj) & _obj($verb, $obj) & _iobj($verb, $iobj) => (SVIO-ynQ-rule $subj (get-
-#instance-name $subj word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj word_index sentence_index) $iobj (get-
-#instance-name $iobj word_index sentence_index))
-#[SVO-ynQ] {2} <SV-ynQ, SVO, SV> TRUTH-QUERY-FLAG($verb, T) & _subj($verb, $subj) & _obj($verb, $obj) => (SVO-ynQ-rule $subj (get-instance-name $subj word_index #sentence_index) $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj word_index sentence_index))
-#[SV-ynQ] {3} <SV> TRUTH-QUERY-FLAG($verb, T) & _subj($verb, $subj) => (SV-ynQ-rule $subj (get-instance-name $subj word_index sentence_index) $verb (get-instance-name $verb #word_index sentence_index))
-#=======================================================================================================================================
-# Q-word questions
-#=======================================================================================================================================
-# Questioned subjecT (NB: these 6 rules send to 3 'whowhat' scheme-helpers)
-#=======================================================================================================================================
-# WHO SUBJECT
-#===============================================================
-#[whosubj-SVIO-Q] {1} <whosubj-SVO-Q, whosubj-SV-Q, SVO, SV, SVIO> interrogative-FLAG(_\$qVar, T) & QUERY-TYPE(_\$qVar, who) & _subj($verb, _\$qVar) & _obj($verb, $z) &
-#_iobj($verb, $iobj) => (whowhatsubj-SVIO-Q-rule $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj word_index sentence_index) $iobj (get-
-#instance-name $iobj word_index sentence_index))
-#[whosubj-SVO-Q] {2} <whosubj-SV-Q, SVO, SV> interrogative-FLAG(_\$qVar, T) & QUERY-TYPE(_\$qVar, who) & _subj($verb, _\$qVar) & _obj($verb, $obj) => (whowhatsubj-SVO-Q-rule 
-#$verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj word_index sentence_index))
-#[whosubj-SV-Q] {3} <SV> interrogative-FLAG(_\$qVar, T) & QUERY-TYPE(_\$qVar, who) & _subj($verb, _\$qVar) => (whowhatsubj-SV-Q-rule $verb (get-instance-name $verb 
-#word_index sentence_index))
-#[whopsubj-Q] {3} <SV> interrogative-FLAG(_\$qVar, T) & QUERY-TYPE(_\$qVar, who) & _psubj($p, _\$qVar) & _pobj($p, $o) => (whowhatpsubj-Q-rule $p (get-instance-name $p 
-#word_index sentence_index) $o (get-instance-name $o word_index sentence_index))
-#===============================================================
-# WHAT SUBJECT
-#===============================================================
-#[whatsubj-SVIO-Q] {1} <whatsubj-SVO-Q, whatsubj-SV-Q, SV, SVO, SVIO> interrogative-FLAG(_\$qVar, T) & QUERY-TYPE(_\$qVar, what) & _subj($verb, _\$qVar) & _obj($verb, $obj)
-# & _iobj($verb, $iobj) => (whowhatsubj-SVIO-Q-rule $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj word_index sentence_index) $iobj
-#(get-instance-name $iobj word_index sentence_index))
-#[whatsubj-SVO-Q] {2} <whatsubj-SV-Q, SVO> interrogative-FLAG(_\$qVar, T) & QUERY-TYPE(_\$qVar, what) & _subj($verb, _\$qVar) & _obj($verb, $obj) => (whowhatsubj-SVO-Q-rule #
-#$verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj word_index sentence_index))
-#[whatsubj-SV-Q] {3} <SV> interrogative-FLAG(_\$qVar, T) & QUERY-TYPE(_\$qVar, what) & _subj($verb, _\$qVar) => (whowhatsubj-SV-Q-rule $verb (get-instance-name $verb 
-#word_index sentence_index))
-#[whatpsubj-Q] {3} <SV> interrogative-FLAG(_\$qVar, T) & QUERY-TYPE(_\$qVar, what) & _psubj($p, _\$qVar) & _pobj($p, $o) => (whowhatpsubj-Q-rule $p (get-instance-name $p 
-#word_index sentence_index) $o (get-instance-name $o word_index sentence_index))
-#==========================================================================================================
-# Questioned object or indirect object (NB: these 6 rules send to 2 'whowhat' scheme helpers)
-#==========================================================================================================
-# WHO OBJECT
-#=============================
-#[whoobj-Q] {2} <whosubj-SV-Q, SV, SVO> interrogative-FLAG(_\$qVar, T) & QUERY-TYPE(_\$qVar, who) & _subj($verb, $subj) & _obj($verb, _\$qVar) => (whowhatobj-Q-rule $subj 
-#(get-instance-name $subj word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index))
-#============================
-# WHO INDIRECT OBJECT
-#============================
-#[whoiobj-Q1] {1} <SVO, whosubj-SV-Q, whosubj-SVO-Q> interrogative-FLAG(_\$qVar, T) & QUERY-TYPE(_\$qVar, who) & _subj($verb, $subj) & _obj($verb, $obj) & _iobj($verb, _\
-#$qVar) => (whowhatiobj-Q-rule $subj (get-instance-name $subj word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name 
-#$obj word_index sentence_index ))
-#=============================
-# WHAT Object
-#=============================
-#[whatobj-Q] {2} <SVO, SV> interrogative-FLAG(_\$qVar, T) & QUERY-TYPE(_\$qVar, what) & _subj($verb, $subj) & _obj($verb, _\$qVar) => (whowhatobj-Q-rule $subj (get-instance-
-#name $subj word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index))
-#=============================
-# WHAT Indirect Object
-#============================
-#[whatiobj-Q] {1} <SVIO, whatsubj-SV-Q, whatsubj-SVO-Q> interrogative-FLAG(_\$qVar, T) & QUERY-TYPE(_\$qVar, what) & _subj($verb, $subj) & _obj($verb, $obj) & _iobj($verb, _\
-#$qVar) => (whowhatiobj-Q-rule $subj (get-instance-name $subj word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name 
-#$obj word_index sentence_index))
-# WHERE
-#[whereSVIO-Q] {1} <SVIO, SVO, SV, whereSVO-Q, whereSV-Q> QUERY-TYPE(_\$qVar, where) & _%atLocation($verb, _\$qVar) & _subj($verb, $subj) & _obj($verb, $obj) & _iobj($verb, #
-#$iobj) => (where-SVIOQ-rule $subj (get-instance-name $subj word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj 
-#word_index sentence_index) $iobj (get-instance-name $iobj word_index sentence_index))
-#[whereSVO-Q] {2} <SVO, SV, whereSV-Q> QUERY-TYPE(_\$qVar, where) & _%atLocation($verb, _\$qVar) & _subj($verb, $subj) & _obj($verb, $obj) => (where-SVOQ-rule $subj (get-
-#instance-name $subj word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj word_index sentence_index))
-# WHEN
-#[whenSVIO-Q] {1} <whenSV-Q, whenSVO-Q, SVIO, SVO, SV> QUERY-TYPE(_\$qVar, when) & _%atTime($verb, _\$qVar) & _subj($verb, $subj) & _obj($verb, $obj) & _iobj($verb, $iobj) 
-#=> (when-SVIOQ-rule $subj (get-instance-name $subj word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj 
-#word_index sentence_index) $iobj (get-instance-name $iobj word_index sentence_index))
-#[whenSVO-Q] {2} <whenSV-Q, whenSVO-Q, SVO, SV> QUERY-TYPE(_\$qVar, when) & _%atTime($verb, _\$qVar) & _subj($verb, $subj) & _obj($verb, $obj) => (when-SVOQ-rule $subj (get-
-#instance-name $subj word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj word_index sentence_index))
-# WHY
-#[whySVIO-Q] {1} <whySVO-Q, whySV-Q, SVIO, SVO, SV> QUERY-TYPE(_\$qVar, why) & _%because($verb, _\$qVar) & _subj($verb, $subj) & _obj($verb, $obj) & _iobj($verb, $iobj) => 
-#(why-SVIOQ-rule $subj (get-instance-name $subj word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj word_index 
-#sentence_index) $iobj (get-instance-name $iobj word_index sentence_index))
-#[whySVO-Q] {2} <whySV-Q, SVO, SV> QUERY-TYPE(_\$qVar, why) & _%because($verb, _\$qVar) & _subj($verb, $subj) & _obj($verb, $obj) => (why-SVOQ-rule $subj (get-instance-name 
-#$subj word_index sentence_index) $verb (get -instance-name $verb word_index sentence_index) $obj (get-instance-name $obj word_index sentence_index))
-# HOW
-#[howSVIO-Q] {1} <howSV-Q, howSVO-Q, SVIO, SVO, SV, SVIO-ynQ> QUERY-TYPE(_\$qVar, how) & how($verb, _\$qVar) & _subj($verb, $subj) & _obj($verb, $obj) & _iobj($verb, $iobj) 
-#=> (how-SVIOQ-rule $subj (get-instance-name $subj word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj 
-#word_index sentence_index) $iobj (get-instance-name $iobj word_index sentence_index))
-#[howSVO-Q] {2} <SVO, SV, howSV-Q> QUERY-TYPE(_\$qVar, how) & how($verb, _\$qVar) & _subj($verb, $subj) & _obj($verb, $obj) => (how-SVOQ-rule $subj (get-instance-name $subj 
-#word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $obj (get-instance-name $obj word_index sentence_index))
-
 

--- a/data/relex2logic-rules.txt
+++ b/data/relex2logic-rules.txt
@@ -74,16 +74,16 @@
 #===================
 [howdegQ] {1} <SV> QUERY-TYPE(_\$qVar, how_much) & _%howdeg($pred, _\$qVar) => (howdegQ-rule $pred (get-instance-name $pred word_index sentence_index))
 #=============================================
-# CHOICE-TYPE QUESTIONS
+# DETERMINER-WHICH QUESTIONS
 #=============================================
 [whichobjQ] {1} <SVO, SV, QDET, QDETPREDADJ> QUERY-FLAG($o, T) & _obj($v, $o) & _subj($v, $s) & _det($o, _\$qVar) => (whichobjQ-rule $o (get-instance-name $o word_index sentence_index) $v (get-instance-name $v word_index sentence_index) $s (get-instance-name $s word_index sentence_index))
 [whichsubjQ] {1} <SV, SVO, QDET, QDETPREDADJ> QUERY-FLAG($s, T) & _subj($v, $s) & _obj($v, $o) & _det($s, _\$qVar) => (whichsubjQ-rule $s (get-instance-name $s word_index sentence_index) $v (get-instance-name $v word_index sentence_index) $o (get-instance-name $o word_index sentence_index))
 [whichpredadjQ] {1} <SVP, SV, QDET, QDETPREDADJ> QUERY-FLAG($s, T) & _predadj($s, $pred) & _det($s, _\$qVar) => (whichpredadjQ-rule $s (get-instance-name $s word_index sentence_index) $pred (get-instance-name $pred word_index sentence_index))
-[whichiobjQ] {1} <SVO, SV, SVIO3, QDET, QDETPREDADJ> QUERY-FLAG($io, T) & _obj($v, $o) & _subj($v, $s) & to($v, $io) & _det($io, _\$qVar) => (whichiobjQ-rule $s (get-instance-name $s word_index sentence_index) $v (get-instance-name $v word_index sentence_index) $o (get-instance-name $o word_index sentence_index) $io (get-instance-name $io word_index sentence_index))
+[whichiobjQ] {1} <SVO, SV, SVIO3> QUERY-FLAG($io, T) & _obj($v, $o) & _subj($v, $s) & to($v, $io) & _det($io, _\$qVar) => (whichiobjQ-rule $s (get-instance-name $s word_index sentence_index) $v (get-instance-name $v word_index sentence_index) $o (get-instance-name $o word_index sentence_index) $io (get-instance-name $io word_index sentence_index))
 #==================================
-#determiner-question-word-questions
+# DETERMINER PREPOSITIONAL-PHRASE-QUESTION-WORDS (e.g. "in which way?"
 #==================================
-[QDET] {2} <> _det($noun, _\$qVar) & QUERY-TYPE(_\$qVar, $qtype) & QUERY-FLAG($noun, T) & $prep($verb, $noun) => (q-det-rule $noun (get-instance-name $noun word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $qtype)
+[QDET] {2} <> _det($noun, _\$qVar) & QUERY-TYPE(_\$qVar, $qtype) & _subj($verb, $subj) => (q-det-rule $noun (get-instance-name $noun word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $qtype)
 [QDETPREDADJ] {2} <> _det($noun, _\$qVar) & QUERY-TYPE(_\$qVar, $qtype) & _predadj($subj, $verb) => (q-det-rule $noun (get-instance-name $noun word_index sentence_index) $verb (get-instance-name $verb word_index sentence_index) $qtype)
 #=============================================
 # END OF QUESTION RULES!
@@ -95,6 +95,12 @@
 [AMOD] {3} <> _amod($N, $A) => (amod-rule $N (get-instance-name $N word_index sentence_index) $A (get-instance-name $A word_index sentence_index))
 
 [ADVMOD] {4} <> _advmod($V, $ADV) => (advmod-rule $V (get-instance-name $V word_index sentence_index) $ADV (get-instance-name $ADV word_index sentence_index))
+
+[ADVERBIALPP] {4} <> _prep($prep, $noun) & _prepadv($verb, $prep) => (advmod-rule $verb (get-instance-name $verb word_index sentence_index) $prep (get-instance-name $prep word_index sentence_index))
+
+[ADJECTIVALPP] {4} <> _prep($prep, $noun) & _prepadj($noun, $prep) => (amod-rule $noun (get-instance-name $noun word_index sentence_index) $prep (get-instance-name $prep word_index sentence_index))
+
+[PP] {4} <> _prep($prep, $noun) => (pp-rule $prep (get-instance-name $prep word_index sentence_index) $noun (get-instance-name $noun word_index sentence_index))
 
 # ============================================
 # unary rules

--- a/src/java_test/relex/test/TestRelEx.java
+++ b/src/java_test/relex/test/TestRelEx.java
@@ -175,7 +175,8 @@ public class TestRelEx
 		                     "_predet(boy, all)\n");
 
 		rc &= test_sentence ("Joan thanked Susan for all the help she had given.",
-		                     "for(thank, help)\n" +
+					"_prepadv(thank, for)\n" +
+					"_pobj(for, help)\n" +
 		                     "_subj(thank, Joan)\n" +
 		                     "_obj(thank, Susan)\n" +
 		                     "_predet(help, all)\n" +
@@ -190,13 +191,15 @@ public class TestRelEx
 	{
 		boolean rc = true;
 		rc &= test_sentence("I had breakfast at 8 am.",
+					"_prepadv(have, at)\n" +
+				    "_pobj(at, am)\n" +
 				    "_obj(have, breakfast)\n"+
-				    "at(have, am)\n" +
 				    "_subj(have, I)\n" +
 				    "_time(am, 8)\n");
 		rc &= test_sentence("I had supper before 6 pm.",
+				    "_prepadv(have, before)\n" +
+				    "_pobj(before, pm)\n" +
 				    "_obj(have, supper)\n" +
-				    "before(have, pm)\n" +
 				    "_subj(have, I)\n" +
 				    "_time(pm, 6)\n");
 
@@ -1245,16 +1248,15 @@ public class TestRelEx
 		return rc;
 	}
 	
-	//Added by Matthew
-	public boolean test_inquisitives()
+	public boolean test_interrogatives()
 	{
 		boolean rc = true;
 		rc &= test_sentence ("What is Socrates?",
-							 "_obj(be, Socrates)\n" +
-							 "_subj(be, _$qVar)\n");
+					 "_obj(be, Socrates)\n" +
+					 "_subj(be, _$qVar)\n");
 
 		rc &= test_sentence ("Who is the teacher?",
-							 "_obj(be, teacher)\n" +
+					 "_obj(be, teacher)\n" +
 		                     "_subj(be, _$qVar)\n");
 
 
@@ -1269,6 +1271,8 @@ public class TestRelEx
 		                     "_det(bullshit, that)\n");
 
 		rc &= test_sentence ("Who told that story to the police?", 
+					"_prepadv(tell, to)\n" +
+					"_pobj(to, police)\n" +
 		                     "to(tell, police)\n" +
 		                     "_obj(tell, story)\n" +
 		                     "_subj(tell, _$qVar)\n" +
@@ -1280,41 +1284,36 @@ public class TestRelEx
 		                     "_subj(give, _$qVar)\n" +
 		                     "_det(idea, that)\n");
 
-		rc &= test_sentence ("What gave that idea to the police?",
-		                     "to(give, police)\n" +
-		                     "_obj(give, idea)\n" +
-		                     "_subj(give, _$qVar)\n" +
-		                     "_det(idea, that)\n");
-
 		rc &= test_sentence ("What did you tell the fuzz?", 
 		                     "_iobj(tell, fuzz)\n" +
 		                     "_obj(tell, _$qVar)\n" +
 		                     "_subj(tell, you)\n");
 
-		rc &= test_sentence ("What did you give to Mary?", 
-		                     "to(give, Mary)\n" +
+		rc &= test_sentence ("What did you give to Mary?",
+					"_prepadv(give, to\n)" +
+					"_pobj(to, Mary)\n" +
 		                     "_obj(give, _$qVar)\n" +
 		                     "_subj(give, you)\n");
 
-		rc &= test_sentence ("Who did you give the slavers?", 
-		                     "_subj(give, you)\n");
-
-		rc &= test_sentence ("Who did you sell to the slavers?",
-		                     "to(sell, to)\n" +
-		                     "_subj(sell, you)\n");
+		rc &= test_sentence ("Whom did you feed to the lions?", 
+					"_prepadv(feed, to)\n" +
+					    "_obj(feed, _$qVar)\n" +
+					    "_subj(feed, you)\n" +
+					    "_pobj(to, lion)\n";
 
 		rc &= test_sentence ("To whom did you sell the children?", 
-		                     "to(sell, _$qVar)\n" +
+		                     "_pobj(to, _$qVar)\n" +
 		                     "_obj(sell, child)\n" +
 		                     "_subj(sell, you)\n");
 
 		rc &= test_sentence ("To what do we owe the pleasure?", 
-		                     "to(owe, _$qVar)\n" +
+		                     "_pobj(to, _$qVar)\n" +
 		                     "_obj(owe, pleasure)\n" +
-							 "_subj(owe, we)\n");
+					"_subj(owe, we)\n");
 
 		rc &= test_sentence ("Who did you sell the children to?",
-		                     "to(sell, to)\n" +
+					"_prepadv(sell, to)\n" +
+					"_pobj(to, _$qVar)\n" +
 		                     "_obj(sell, child)\n" +
 		                     "_subj(sell, you)\n");
 
@@ -1369,17 +1368,18 @@ public class TestRelEx
 		                     "_predadj(you, mad)\n");
 	
 		rc &= test_sentence ("Is the book under the table?",
-		                     "under(book, table)\n" +
-							 "_subj(be, book)\n");
-	
+				   "_pobj(under, table)\n" +
+				    "_prepadj(book, under)\n" +
+				    "_subj(_%copula, book)\n";
+
 		rc &= test_sentence ("Does he seem mad?",
 		                     "_to-be(seem, mad)\n" +
 		                     "_subj(seem, he)\n");
 
-		rc &= test_sentence ("Does she want to help us?",	
+		rc &= test_sentence ("Does she want to help us?",
 		                     "_obj(help, us)\n" +
 		                     "_to-do(want, help)\n" +
-		                     "_subj(want, she)\n");		
+		                     "_subj(want, she)\n");
 
 		rc &= test_sentence ("Does she want you to help us?",
 		                     "_obj(help, us)\n" +
@@ -1408,9 +1408,9 @@ public class TestRelEx
 		rc &= test_sentence ("Did you sleep?",
 		                     "_subj(sleep, you)\n");
 
-		rc &= test_sentence ("Did you eat the leftover baba-ganoush?",
-		                     "_obj(eat, leftover)\n" +
-		                     "_to-be(eat, baba-ganoush)\n" +
+		rc &= test_sentence ("Did you eat the leftover baba-pizza?",
+					"_obj(eat, pizza)\n" +
+					"_amod(pizza, leftover)\n" +
 		                     "_subj(eat, you)\n");
 
 		rc &= test_sentence ("Did you give her the money?",
@@ -1419,13 +1419,10 @@ public class TestRelEx
 		                     "_subj(give, you)\n");
 
 		rc &= test_sentence ("Did you give the money to her?",
-		                     "to(give, her)\n" +
+					"_prepadv(give, to)\n" +
+					"_pobj(to, her)\n" +
 		                     "_obj(give, money)\n" +
 		                     "_subj(give, you)\n");
-
-		rc &= test_sentence ("The book is under the table?",
-		                     "_pobj(under, table)\n" +
-		                     "_psubj(under, book)\n");
 
 		rc &= test_sentence ("Maybe she eats lunch.",
 		                     "_obj(eat, lunch)\n" +
@@ -1505,14 +1502,17 @@ public class TestRelEx
 		                     "_subj(_%copula, party)\n");
 
 		rc &= test_sentence ("Why do you live?",
+				   "_%because(live, _$qVar)\n" +
 		                     "_subj(live, you)\n");
 
 		rc &= test_sentence ("Why do you like terrible music?",
 		                     "_obj(like, music)\n" +
 		                     "_subj(like, you)\n" +
-							 "_amod(music, terrible)\n");
+					"_%because(like, _$qVar)/n" +
+					"_amod(music, terrible)\n");
 
-		rc &= test_sentence ("Why are you such a fool?", 
+		rc &= test_sentence ("Why are you such a fool?",
+					"_%because(be, _$qVar)\n" +
 		                     "_obj(be, fool)\n" +
 		                     "_subj(be, you)\n");
 
@@ -1522,7 +1522,7 @@ public class TestRelEx
 
 		rc &= test_sentence ("How was the party?", 
 		                     "how(_%copula, _$qVar)\n" +
-							 "_subj(_%copula, party)\n");
+					"_subj(_%copula, party)\n");
 
 		rc &= test_sentence ("How is your food?",
 		                     "_poss(food, you)\n" +
@@ -1540,26 +1540,34 @@ public class TestRelEx
 		                     "_quantity(book, _$qVar)\n");
 
 		rc &= test_sentence ("How fast does it go?",
-		                     "_advmod(fast, _$qVar)\n" +
+					"_subj(go, it)\n" +
+					"_advmod(go, fast)\n" +
+					"_%howdeg(fast, _$qVar)\n" +
 		                     "_subj(go, it)\n");
 
+		rc &= test_sentence ("How stupid are you?",
+					"_%howdeg(stupid, _$qVar)\n" +
+					"_predadj(stupid, you)\n" +
+					"_subj(stupid, you)\n");
+
 		rc &= test_sentence ("Which girl do you like?",
+					"_det(girl, _$qVar)\n" +
 		                     "_obj(like, girl)\n" +
-		                     "_subj(like, you)\n" +
-		                     "_quantity(girl, _$qVar)\n");
+		                     "_subj(like, you)\n");
 
 		rc &= test_sentence ("Which girl likes you?",
 		                     "_obj(like, you)\n" +
 		                     "_subj(like, girl)\n" +
-		                     "_quantity(girl, _$qVar)\n");
+		                     "_det(girl, _$qVar)\n");
 
 		rc &= test_sentence ("Which girl is crazy?",
-		                     "_quantity(girl, _$qVar)\n" +
+		                     "_det(girl, _$qVar)\n" +
 		                     "_predadj(girl, crazy)\n");
 
 		rc &= test_sentence ("The books were written by Charles Dickens.",
 		                     "_obj(write, book)\n" +
-		                     "by(write, Charles_Dickens)\n");
+					"_prepadv(write, by)\n" +
+					"_pobj(by, Bob)\n");
 
 		rc &= test_sentence ("The books are published.",
 		                     "_obj(publish, book)\n");
@@ -1567,7 +1575,8 @@ public class TestRelEx
 		rc &= test_sentence ("I did my homework, and I went to school.",
 		                     "_obj(do, homework)\n" +
 		                     "_subj(do, I)\n" +
-		                     "to(go, school)\n" +
+		                     "_pobj(to, school)\n" +
+					"_advmod(go, to)\n" +
 		                     "_subj(go, I)\n" +
 		                     "_poss(homework, me)\n");
 
@@ -1582,66 +1591,24 @@ public class TestRelEx
 		                     "_predadj(Joan, happy)\n");
 
 		rc &= test_sentence ("I think that dogs can fly.",
-		                     "that(think, fly)\n" +
+				    "_rep(think, that)\n" +
+				    "_comp(that, fly)\n" +
 		                     "_subj(think, I)\n" +
 		                     "_subj(fly, dog)\n");
 
 		rc &= test_sentence ("He is glad that she won.",
-		                     "that(glad, win)\n" +
+		                     "_rep(glad, that)\n" +
+					"_comp(that, win)\n" +
 		                     "_subj(win, she)\n" +
 		                     "_predadj(he, glad)\n");
 
 		rc &= test_sentence ("He ran so quickly that he flew.",
+				    "_comp(that, fly)\n" +
 		                     "_advmod(quickly, so)\n" +
 		                     "_subj(fly, he)\n" +
 		                     "that(run, fly)\n" +
 		                     "_advmod(run, quickly)\n" +
 		                     "_subj(run, he)\n");
-
-		rc &= test_sentence ("I had dinner at 6 pm",
-		                     "_obj(have, dinner)\n" +
-		                     "at(have, pm)\n" +
-		                     "_subj(have, I)\n" +
-		                     "_time(pm, 6)\n");
-
-		rc &= test_sentence ("I went to sleep at 1 am",
-		                     "to(go, sleep)\n" +
-		                     "_subj(go, I)\n" +
-		                     "_time(am, 1)\n" +
-		                     "at(sleep, am)\n");
-
-		rc &= test_sentence ("Who farted?",
-		                     "_subj(fart, _$qVar)\n");
-
-		rc &= test_sentence ("What happened?",
-		                     "_subj(happen, _$qVar)\n");
-
-		rc &= test_sentence ("What killed him?",
-		                     "_obj(kill, him)\n" +
-		                     "_subj(kill, _$qVar)\n");
-
-		rc &= test_sentence ("Who ate the pizza?",
-		                     "_obj(eat, pizza)\n" +
-		                     "_subj(eat, _$qVar)\n");
-
-		rc &= test_sentence ("What gave you that idea?",
-		                     "_iobj(give, you)\n" +
-		                     "_obj(give, idea)\n" +
-		                     "_subj(give, _$qVar)\n" +
-		                     "_det(idea, that)\n");
-
-		rc &= test_sentence ("Who told you that?",
-		                     "_iobj(tell, you)\n" +
-		                     "_obj(tell, that)\n" +
-		                     "_subj(tell, _$qVar)\n");
-
-		rc &= test_sentence ("What is for dinner?",
-		                     "_pobj(for, dinner)\n" +
-		                     "_psubj(for, _$qVar)\n");
-
-		rc &= test_sentence ("Who's on first?",
-		                     "_pobj(on, first)\n" +
-		                     "_psubj(on, _$qVar)\n");
 
 		rc &= test_sentence ("Who are you?",
 		                     "_subj(_%copula, you)\n");
@@ -1661,10 +1628,11 @@ public class TestRelEx
 
 		rc &= test_sentence ("Why did you give him the money?",
 		                     "_iobj(give, him)\n" +
-							 "_obj(give, money)\n" +
-							 "_subj(give, you)\n");
+					 "_obj(give, money)\n" +
+					 "_subj(give, you)\n");
 
 		rc &= test_sentence ("Why are you so stupid?",
+					"_%because(stupid, _$qVar)\n" +
 		                     "_advmod(stupid, so)\n" +
 		                     "_predadj(you, stupid)\n");
 
@@ -1679,9 +1647,127 @@ public class TestRelEx
 		                     "how(send, _$qVar)\n" +
 		                     "_subj(send, you)\n");
 
-		report(rc, "Inquisitives");
+		report(rc, "Interrogatives");
 		return rc;
 	}
+
+	public boolean test_adverbials_and_adjectivals()
+	{
+		boolean rc = true;
+		rc &= test_sentence ("He ran like the wind.",
+					"_prepadv(run, like)\n" +
+					"_subj(run, he)\n" +
+					"_pobj(like, wind)\n");
+
+		rc &= test_sentence ("He was boring to an insufferable degree.",
+					"_prepadv(boring, to)\n" +
+					"_amod(degree, insufferable)\n" +
+					"_pobj(to, degree)\n" +
+					"_predadj(he, boring)\n");
+
+		rc &= test_sentence ("He spoke in order to impress himself.",
+					"_goal(speak, impress)\n" +
+					"_subj(speak, he)\n" +
+					"_obj(impress, himself)\n");
+
+		rc &= test_sentence ("On Tuesday, he slept late.",
+				"_prepadv(sleep, on)\n" +
+				"_advmod(sleep, late)\n" +
+				"_subj(sleep, he)\n" +
+				"_pobj(on, Tuesday)\n");
+
+		rc &= test_sentence ("Often, people confused him.",
+				"_obj(confuse, him)\n" +
+				"_advmod(confuse, often)\n" +
+				"_subj(confuse, people)\n");
+
+		report(rc, "Adverbials and Adjectivals");
+		return rc;
+	}
+
+	public boolean test_complementation()
+	{
+		boolean rc = true;
+		rc &= test_sentence ("The dog chasing the bird is happy.",
+					"_obj(chase, bird)\n" +
+					"_predadj(dog, happy)\n" +
+					"_comp(dog, chase)\n");
+
+		rc &= test_sentence ("My sister always opens her mouth while eating.",
+					"_obj(open, mouth)\n" +
+					"_advmod(open, always)\n" +
+					"_compmod(open, while)\n" +
+					"_subj(open, My_sister)\n" +
+					"_comp(while, eat)\n" +
+					"_poss(mouth, her)\n");
+
+		rc &= test_sentence ("Aaron always reads while he rides the train.",
+					"_advmod(read, always)\n" +
+					"_compmod(read, while)\n" +
+					"_subj(read, Aaron)\n" +
+					"_obj(ride, train)\n" +
+					"_subj(ride, he)\n" +
+					"_comp(while, ride)\n");
+
+		rc &= test_sentence ("I sing because I'm happy.",
+					"_%because(sing, because)\n" +
+					"_subj(sing, I)\n" +
+					"_predadj(I, happy)\n" +
+					"_comp(because, happy)\n");
+
+		rc &= test_sentence ("I know that you love me.",
+					"_rep(know, that)\n" +
+					"_subj(know, I)\n" +
+					"_obj(love, me)\n" +
+					"_subj(love, you)\n" +
+					"_comp(that, love)\n");
+
+		rc &= test_sentence ("I know you hate me.",
+					"_rep(know, hate)\n" +
+					"_subj(know, I)\n" +
+					"_obj(hate, me)\n" +
+					"_subj(hate, you)\n");
+
+		rc &= test_sentence ("I am certain that you are insane.",
+					"_rep(certain, that)\n" +
+					"_predadj(you, insane)\n" +
+					"_comp(that, insane)\n" +
+					"_predadj(I, certain)\n");
+
+		rc &= test_sentence ("The idea that he would invent AGI obsessed him.",
+					"_obj(obsess, him)\n" +
+					"_subj(obsess, idea)\n" +
+					"_to-do(would, invent)\n" +
+					"_comp(that, would)\n" +
+					"_obj(invent, AGI)\n" +
+					"_subj(invent, he)\n" +
+					"_rep(idea, that)\n");
+
+		report(rc, "Complementation");
+		return rc;
+	}
+
+
+	public boolean test_special_preposition_stuff()
+	{
+		boolean rc = true;
+		rc &= test_sentence ("Who did you give the book to?",
+				"_prepadv(give, to)\n" +
+				"_obj(give, book)\n" +
+				"_subj(give, you)\n" +
+				"_pobj(to, _$qVar)\n");
+
+		rc &= test_sentence ("The people on whom you rely are sick.",
+				"_prepadv(rely, on)\n" +
+				"_subj(rely, you)\n" +
+				"_pobj(on, people)\n" +
+				"_comp(on, rely)\n" +
+				"_predadj(people, sick)\n");
+
+		report(rc, "Special preposition stuff");
+		return rc;
+	}
+
 
 	public static void main(String[] args)
 	{

--- a/src/java_test/relex/test/TestRelEx.java
+++ b/src/java_test/relex/test/TestRelEx.java
@@ -162,25 +162,26 @@ public class TestRelEx
 		                     "_obj(eat, cookie)\n" +
 		                     "_det(cookie, that)\n");
 		rc &= test_sentence ("All my writings are bad.",
-		                     "_predet(writings, all)\n" +
+		                     "_quantity(writings, all)\n" +
 		                     "_poss(writings, me)\n" +
 		                     "_predadj(writings, bad)\n");
 		rc &= test_sentence ("All his designs are bad.",
-		                     "_predet(design, all)\n" +
+		                     "_quantity(design, all)\n" +
 		                     "_poss(design, him)\n" +
 		                     "_predadj(design, bad)\n");
 		rc &= test_sentence ("All the boys knew it.",
 		                     "_subj(know, boy)\n" +
 		                     "_obj(know, it)\n" +
-		                     "_predet(boy, all)\n");
+		                     "_quantity(boy, all)\n");
 
 		rc &= test_sentence ("Joan thanked Susan for all the help she had given.",
 					"_advmod(thank, for)\n" +
 					"_pobj(for, help)\n" +
 		                     "_subj(thank, Joan)\n" +
 		                     "_obj(thank, Susan)\n" +
-		                     "_predet(help, all)\n" +
+		                     "_quantity(help, all)\n" +
 		                     "_subj(give, she)\n" +
+					"_relmod(help, she)\n" +
 		                     "_obj(give, help)\n");
 
 		report(rc, "Determiners");
@@ -211,187 +212,190 @@ public class TestRelEx
 	{
 		boolean rc = true;
 		rc &= test_sentence ("Some people like pigs less than dogs.",
-		                     "_advmod(like, less)\n" +
+		                     "_compdeg(like, less)\n" +
 		                     "_obj(like, pig)\n" +
-		                     "_quantity(people, some)\n" +
 		                     "_subj(like, people)\n" +
-		                     "than(pig, dog)\n");
+		                     "than(pig, dog)\n" +
+					"_comparative(like, pig)\n" +
+					"comp_arg(like, dog)\n" +
+		                     "_quantity(people, some)\n");
 
 		rc &= test_sentence ("Some people like pigs more than dogs.",
-		                     "_advmod(like, more)\n" +
+		                     "_compdeg(like, more)\n" +
 		                     "_obj(like, pig)\n" +
-		                     "_quantity(people, some)\n" +
 		                     "_subj(like, people)\n" +
-		                     "than(pig, dog)\n");
+		                     "than(pig, dog)\n" +
+					"_comparative(like, pig)\n" +
+					"comp_arg(like, dog)\n" +
+		                     "_quantity(people, some)\n");
 		//Non-equal Gradable : Two entities one feature "more/less"
 
 		rc &= test_sentence ("He is more intelligent than John.",
-				    "than(he, John)\n" +
+				    "_compdeg(intelligent, more)\n"+
 				    "_comparative(intelligent, he)\n" +
-				    "degree(intelligent, comparative)\n"+
-				    "_advmod(intelligent, more)\n"+
+					"comp_arg(intelligent, John)\n" +
+				    "than(he, John)\n" +
 				    "_predadj(he, intelligent)\n");
 
 		rc &= test_sentence ("He is less intelligent than John.",
-				    "than(he, John)\n" +
+				    "_compdeg(intelligent, less)\n"+
 				    "_comparative(intelligent, he)\n" +
-				    "degree(intelligent, comparative)\n"+
-				    "_advmod(intelligent, less)\n"+
+				    "than(he, John)\n" +
+					"comp_arg(intelligent, John)\n" +
 				    "_predadj(he, intelligent)\n");
 
 		rc &= test_sentence ("He runs more quickly than John.",
 				    "_advmod(run, quickly)\n"+
-				    "_advmod(quickly, more)\n"+
 				    "_subj(run, he)\n" +
-				    "than(he, John)\n" +
-				    "_comparative(quickly, run)\n" +
-				    "degree(quickly, comparative)\n");
+				    "_compdeg(quickly, more)\n"+
+				    "_comparative(run, quickly)\n" +
+					"comp_arg(run, John)\n" +
+				    "than(he, John)\n");
 
 		rc &= test_sentence ("He runs less quickly than John.",
 				    "_advmod(run, quickly)\n" +
 				    "_subj(run, he)\n" +
-				    "_advmod(quickly, less)\n"+
-				    "than(he, John)\n" +
-				    "_comparative(quickly, run)\n" +
-				    "degree(quickly, comparative)\n");
+				    "_compdeg(quickly, less)\n"+
+				    "_comparative(run, quickly)\n" +
+					"comp_arg(run, John)\n" +
+				    "than(he, John)\n");
 
 		rc &= test_sentence ("He runs more quickly than John does.",
 				    "_advmod(run, quickly)\n" +
-				    "_advmod(quickly, more)\n"+
 				    "_subj(run, he)\n" +
+				    "_advmod(do, quickly)\n" +
 				    "_subj(do, John)\n"+
-				    "than(he, John)\n" +
-				    "_comparative(quickly, run)\n" +
-				    "degree(quickly, comparative)\n");
+				    "_compdeg(quickly, more)\n"+
+				    "_comparative(run, quickly)\n" +
+				    "than(he, John)\n");
 
-		// This sentence is ungrammatical but commonly used by
-		// non-native English speakers
 		rc &= test_sentence ("He runs less quickly than John does.",
 				    "_advmod(run, quickly)\n" +
 				    "_subj(run, he)\n" +
+					"_advmod(do, quickly)\n" +
 				    "_subj(do, John)\n"+
-				    "_advmod(quickly, less)\n"+
+				    "_compdeg(quickly, less)\n"+
 				    "than(he, John)\n" +
-				    "_comparative(quickly, run)\n" +
-				    "degree(quickly, comparative)\n");
+				    "_comparative(run, quickly)\n");
 
 		rc &= test_sentence ("He runs slower than John does.",
-				    "_advmod(run, slow)\n" +
+				    "_advmod(run, slower)\n" +
 				    "_subj(run, he)\n" +
 				    "_subj(do, John)\n"+
 				    "than(he, John)\n" +
-				    "_comparative(slow, run)\n" +
-				    "degree(slow, comparative)\n");
+				    "_comparative(run, slower)\n" +
+				    "_compdeg(slow, more)\n");
 
 		rc &= test_sentence ("He runs more than John.",
-				    "_obj(run, more)\n" +
+					"_compdeg(run, more)\n" +
 				    "_subj(run, he)\n" +
-				    "than(he, John)\n"+
-				    "_comparative(more, run)\n"+
-				    "degree(more, comparative)\n");
+				    "than(he, John)\n" +
+					"_comparative(run, less)\n" +
+					"comp_arg(run, John)\n");
 
 		rc &= test_sentence ("He runs less than John.",
-				    "_obj(run, less)\n" +
+					"_compdeg(run, less)\n" +
 				    "_subj(run, he)\n" +
 				    "than(he, John)\n"+
-				    "_comparative(less, run)\n"+
-				    "degree(less, comparative)\n");
+					"_comparative(run, less)\n" +
+					"comp_arg(run, John)\n");
 
 		rc &= test_sentence ("He runs faster than John.",
 				    "than(he, John)\n" +
-				    "_comparative(fast, run)\n" +
+				    "_comparative(run, faster)\n" +
 				    "_subj(run, he)\n"+
-				    "_advmod(run, fast)\n"+
-				    "degree(fast, comparative)\n");
+				    "_advmod(run, faster)\n" +
+					"comp_arg(run, John)\n" +
+				    "_compdeg(faster, more)\n");
 
 		rc &= test_sentence ("He runs more slowly than John.",
 				    "than(he, John)\n" +
 				    "_subj(run, he)\n" +
-				    "_advmod(slowly, more)\n"+
-				    "_comparative(slowly, run)\n"+
+				    "_compdeg(slowly, more)\n"+
+				    "_comparative(run, slowly)\n"+
 				    "_advmod(run, slowly)\n"+
-				    "degree(slowly, comparative)\n");
+					"comp_arg(run, John)\n");
 
 		rc &= test_sentence ("He runs less slowly than John.",
 				    "than(he, John)\n" +
 				    "_subj(run, he)\n" +
-				    "_comparative(slowly, run)\n"+
-				    "_advmod(run, slowly)\n"+
-				    "_advmod(slowly, less)\n"+
-				    "degree(slowly, comparative)\n");
+				    "_comparative(run, slowly)\n"+
+				    "_advmod(run, slowly)\n" +
+				    "_compdeg(slowly, less)\n" +
+					"comp_arg(run, John)\n");
 
 		rc &= test_sentence ("He runs more miles than John does.",
-				    "than(he, John)\n" +
+				    "_obj(run, mile)\n" +
 				    "_subj(run, he)\n" +
-				    "_subj(do, John)\n"+
-				    "_obj(run, mile)\n"+
-				    "_comparative(mile, run)\n"+
-				    "_quantity(mile, more)\n"+
-				    "degree(more, comparative)\n");
+				    "_subj(do, John)\n" +
+				    "_quantity(mile, more)\n" +
+					"_compamt(mile, more)\n" +
+				    "_comparative(run, mile)\n" +
+				    "than(he, John)\n");
 
 		rc &= test_sentence ("He runs fewer miles than John does.",
-				    "than(he, John)\n" +
-				    "_subj(run, he)\n" +
-				    "_subj(do, John)\n"+
-				    "_obj(run, mile)\n"+
-				    "_comparative(mile, run)\n"+
-				    "_quantity(mile, fewer)\n"+
-				    "degree(fewer, comparative)\n");
-
-		rc &= test_sentence ("He runs many more miles than John does.",
-				    "than(he, John)\n" +
-				    "_comparative(mile, run)\n"+
 				    "_obj(run, mile)\n"+
 				    "_subj(run, he)\n" +
 				    "_subj(do, John)\n" +
-				    "_quantity(mile, many)\n"+
-				    "degree(more, comparative)\n");
+				    "_quantity(mile, fewer)\n" +
+					"_compamt(mile, fewer)\n" +
+				    "_comparative(run, mile)\n" +
+				    "than(he, John)\n");
+
+		rc &= test_sentence ("He runs many more miles than John does.",
+				    "than(he, John)\n" +
+				    "_comparative(run, mile)\n" +
+				    "_obj(run, mile)\n" +
+				    "_subj(run, he)\n" +
+				    "_subj(do, John)\n" +
+				    "_quantity(more, many)\n" +
+				    "_compamt(mile, more)\n");
 
 
 		rc &= test_sentence ("He runs ten more miles than John.",
-				    "_obj(run, mile)\n"+
+				    "_obj(run, mile)\n" +
 				    "_subj(run, he)\n" +
 				    "than(he, John)\n" +
-				    "_comparative(mile, run)\n"+
-				    "_quantity(mile, ten)\n" +
-				    "numeric-FLAG(ten, T)\n" +
-				    "degree(more, comparative)\n");
+					"comp_arg(run, John)\n" +
+				    "_comparative(run, mile)\n"+
+				    "_quantity(more, ten)\n" +
+				    "_compamt(mile, more)\n");
 
 		rc &= test_sentence ("He runs almost ten more miles than John does.",
-				    "_obj(run, mile)\n"+
-				    "_subj(run, he)\n"+
-				    "_comparative(mile, run)\n"+
-				    "_subj(do, John)\n"+
-				    "than(he, John)\n"+
-				    "_quantity_mod(ten, almost)\n"+
-				    "_quantity(mile, ten)\n"+
-				    "numeric-FLAG(ten, T)\n" +
-				    "degree(more, comparative)\n");
+				    "_obj(run, mile)\n" +
+				    "_subj(run, he)\n" +
+				    "_subj(do, John)\n" +
+				    "_quantity(more, ten)\n" +
+				    "_comparative(run, mile)\n" +
+				    "_quantity_mod(ten, almost)\n" +
+					"_compamt(mile, more)\n" +
+				    "than(he, John)\n");
 
 		rc &= test_sentence ("He runs more often than John.",
-				    "_subj(run, he)\n"+
-				    "_advmod(often, more)\n"+
-				    "_advmod(run, often)\n"+
-				    "_comparative(often, run)\n"+
-				    "than(he, John)\n"+
-				    "degree(often, comparative)\n");
+				    "_subj(run, he)\n" +
+					"comp_arg(run, John)\n" +
+				    "_compdeg(often, more)\n" +
+				    "_advmod(run, often)\n" +
+				    "_comparative(run, often)\n" +
+				    "than(he, John)\n");
 
 		rc &= test_sentence ("He runs less often than John.",
 				    "_subj(run, he)\n"+
-				    "_advmod(often, less)\n"+
+					"comp_arg(run, John)\n" +
+				    "_compdeg(often, less)\n"+
 				    "_advmod(run, often)\n"+
-				    "_comparative(often, run)\n"+
-				    "than(he, John)\n"+
-				    "degree(often, comparative)\n");
+				    "_advmod(run, here)\n"+
+				    "_comparative(run, often)\n"+
+				    "than(he, John)\n");
 
 		rc &= test_sentence ("He runs here more often than John.",
 				    "_advmod(run, here)\n"+
-				    "_advmod(often, more)\n"+
+				    "_compdeg(often, more)\n"+
 				    "_advmod(run, often)\n"+
 				    "_subj(run, he)\n"+
-				    "_comparative(often, run)\n"+
-				    "than(he, John)\n"+
-				    "degree(often, comparative)\n");
+					"comp_arg(run, John)\n" +
+				    "_comparative(run, often)\n"+
+				    "than(he, John)\n");
 
 		rc &= test_sentence ("He runs here less often than John.",
 				    "_advmod(run, here)\n"+
@@ -405,8 +409,9 @@ public class TestRelEx
 		rc &= test_sentence ("He is faster than John.",
 				    "than(he, John)\n"+
 				    "_predadj(he, fast)\n"+
-				    "_comparative(fast, he)\n"+
-				    "degree(fast, comparative)\n");
+					"comp_arg(fast, John)\n" +
+				    "_comparative(he, fast)\n"+
+				    "_compdeg(fast, more)\n");
 
 		rc &= test_sentence ("He is faster than John is.",
 				    "than(he, John)\n"+
@@ -599,22 +604,20 @@ public class TestRelEx
 				    "degree(often, comparative)\n");
 
 		rc &= test_sentence ("Russian grammar is more difficult than English grammar.",
+				    "_compdeg(difficult, more)\n"+
 				    "_comparative(difficult, grammar)\n"+
+				    "_amod(grammar, Russian)\n"+
 				    "than(grammar, grammar)\n"+
-				    "_amod(grammar, Russian)\n"+ //When link-grammar uses A, relex should use _amod it will use A instead of AN; will be  updated in next linkgrammer version
 				    "_predadj(grammar, difficult)\n"+
-				    "_amod(grammar, English)\n"+
-				    "_advmod(difficult, more)\n"+
-				    "degree(difficult, comparative)\n");
+				    "_amod(grammar, English)\n");
 
 		rc &= test_sentence ("Russian grammar is less difficult than English grammar.",
+				    "_compdeg(difficult, less)\n"+
 				    "_comparative(difficult, grammar)\n"+
-				    "than(grammar, grammar)\n"+
 				    "_amod(grammar, Russian)\n"+
+				    "than(grammar, grammar)\n"+
 				    "_predadj(grammar, difficult)\n"+
-				    "_amod(grammar, English)\n"+
-				    "_advmod(difficult, less)\n"+
-				    "degree(difficult, comparative)\n");
+				    "_amod(grammar, English)\n");
 
 		rc &= test_sentence ("My sister is much more intelligent than me.",
 				    "_amod(much, intelligent)\n"+
@@ -996,23 +999,26 @@ public class TestRelEx
 		rc &= test_sentence ("Mike runs as fast as he did last year.",
 			"_subj(do, he)\n"+
 			"_subj(run, Mike)\n"+
-			"as(fast, he)\n"+
+			"_compdeg(fast, as)\n"+
+			"_comp(as, do)\n" +
 			"_advmod(run, fast)\n"+
 			"_advmod(do, year)\n"+
+			"_advmod(do, fast)\n" +
 			"_amod(year, last)\n"+
 			"than(Mike, he)\n");
 
 		rc &= test_sentence ("The kick was as soft as the first.",
 			"_predadj(kick, soft)\n"+
-			"as(kick, first)\n");
+			"_advmod(soft, as)\n");
 
 		rc &= test_sentence ("He is as smart as I ever expected him to be.",
 			"_predadj(he, smart)\n"+
 			"_subj(expect, I)\n"+
-			"_obj(expect, him)\n"+
-			"as(smart, expect)\n"+
+			"_to-do(expect, be)\n"+
+			"_comp(as, expect)\n"+
 			"_advmod(expect, ever)\n"+
-			"_to-do(smart, be)\n");
+			"_subj(be, him)\n" +
+			"_compdeg(smart, as)\n");
 			
 		report(rc, "Equatives");
 		return rc;
@@ -1058,17 +1064,21 @@ public class TestRelEx
 		rc &= test_sentence ("We ate dinner at home and went to the movies.",
 		                     "_obj(eat, dinner)\n" +
 		                     "conj_and(eat, go)\n" +
-		                     "at(eat, home)\n" +
+					"_advmod(eat, at)\n" +
+		                     "_pobj(at, home)\n" +
 		                     "_subj(eat, we)\n" +
-		                     "to(go, movie)\n" +
+					"_advmod(go, to)\n" +
+		                     "_pobj(to, movie)\n" +
 		                     "_subj(go, we)\n");
 		// verb with more modifiers
 		rc &= test_sentence ("We ate a late dinner at home and went out to the movies afterwards.",
 		                     "_obj(eat, dinner)\n" +
 		                     "conj_and(eat, go_out)\n" +
-		                     "at(eat, home)\n" +
+					"_advmod(eat, at)\n" +
+					"_advmod(go_out, to)\n" +
+		                     "_pobj(at, home)\n" +
 		                     "_subj(eat, we)\n" +
-		                     "to(go_out, movie)\n" +
+		                     "_pobj(to, movie)\n" +
 		                     "_advmod(go_out, afterwards)\n" +
 		                     "_subj(go_out, we)\n" +
 		                     "_amod(dinner, late)\n");
@@ -1092,8 +1102,7 @@ public class TestRelEx
 		                     "_advmod(quickly, very)\n");
 		// conjoined adverbs with out modifiers
 		rc &= test_sentence ("She handled it quickly and gracefully.",
-		                     "_obj(handle, quickly)\n" +
-		                     "_obj(handle, gracefully)\n" +
+		                     "_obj(handle, it)\n" +
 		                     "_advmod(handle, quickly)\n" +
 		                     "_advmod(handle, gracefully)\n" +
 		                     "_subj(handle, she)\n" +
@@ -1111,20 +1120,22 @@ public class TestRelEx
 		rc &= test_sentence ("The collision was between the little car and the big truck.",
 		                     "_pobj(between, car)\n" +
 		                     "_pobj(between, truck)\n" +
+					"_pobj(between, and)\n" +
 		                     "_psubj(between, collision)\n" +
 		                     "_amod(truck, big)\n" +
 		                     "_amod(car, little)\n" +
+					"conj_prep(between, and)\n" +
 		                     "conj_and(car, truck)\n");
 		// Names Modifiers and conjunction
 		rc &= test_sentence ("Big Tom and Angry Sue went to the movies.",
-		                     "to(go, movie)\n" +
+		                     "_pobj(to, movie)\n" +
+					"_advmod(go, to)\n" +
 		                     "_subj(go, Big_Tom)\n" +
 		                     "_subj(go, Angry_Sue)\n" +
 		                     "conj_and(Big_Tom, Angry_Sue)\n");
                 //Correlative conjunction
                 rc &= test_sentence ("I could use neither the lorry nor the van.",
-                            "_to-do(could, use)\n"+
-                            "_quantity(lorry, neither)\n"+
+                            "_modal(could, use)\n"+
                             "conj_neither_nor(lorry, van)\n"+
                             "_obj(use, lorry)\n"+
                             "_obj(use, van)\n"+
@@ -1143,14 +1154,16 @@ public class TestRelEx
 		                        "_amod(nurse, registered)\n" +
 		                        "_advmod(live, next_door)\n" +
 		                        "_subj(live, woman)\n" +
-		                        "who(woman, live)\n");
+					"_rel(who, live)\n" +
+					"_relmod(woman, who)\n");
 
 		rc &= test_sentence ("A player who is injured has to leave the field.",
 		                        "_to-do(have, leave)\n" +
 		                        "_subj(have, player)\n" +
 		                        "_obj(leave, field)\n" +
+					"_rel(who, injured)\n" +
 		                        "_predadj(player, injured)\n" +
-		                        "who(player, injured)\n" );
+					"_relmod(player, who)\n");
 
 		rc &= test_sentence ("Pizza, which most people love, is not very healthy.",
 		                        "_advmod(very, not)\n" +
@@ -1163,51 +1176,63 @@ public class TestRelEx
 
 		rc &= test_sentence ("The restaurant which belongs to my aunt is very famous.",
 		                        "_advmod(famous, very)\n" +
-		                        "to(belong, aunt)\n" +
+		                        "_advmod(belong, to)\n" +
 		                        "_subj(belong, restaurant)\n" +
 		                        "_poss(aunt, me)\n" +
-		                        "which(restaurant, belong)\n" +
-		                        "_predadj(restaurant, famous)\n");
+					"_pobj(to, aunt)\n" +
+					"_rel(which, belong)\n" +
+		                        "_predadj(restaurant, famous)\n" +
+					"_relmod(restaurant, which)\n");
 
 		rc &= test_sentence ("The books which I read in the library were written by Charles Dickens.",
 		                        "_obj(write, book)\n" +
-		                        "by(write, Charles_Dickens)\n" +
+					"_advmod(write, by)\n" +
 		                        "_obj(read, book)\n" +
-		                        "in(read, library)\n" +
+					"_advmod(read, in)\n" +
 		                        "_subj(read, I)\n" +
-		                        "which(book, read)\n");
+					"_pobj(in, library)\n" +
+					"_rel(which, read)\n" +
+					"_relmod(book, which)\n" +
+					"_pobj(by, Charles_Dickens)\n");
 
 		rc &= test_sentence("This is the book whose author I met in a library.",
 		                       "_obj(be, book)\n" +
 		                       "_subj(be, this)\n" +
 		                       "_obj(meet, author)\n" +
-		                       "in(meet, library)\n" +
+					"_advmod(meet, in)\n" +
 		                       "_subj(meet, I)\n" +
-		                       "whose(book, author)\n");
+		                       "_pobj(in, library)\n" +
+					"_pobj(whose, author)\n" +
+		                       "_det(book, whose)\n");
 
 		rc &= test_sentence("The book that Jack lent me is very boring.",
 		                       "_advmod(boring, very)\n" +
-		                       "_iobj(lend, book)\n" +
-		                       "_obj(lend, me)\n" +
+		                       "_obj(lend, book)\n" +
+		                       "_iobj(lend, me)\n" +
 		                       "_subj(lend, Jack)\n" +
-		                       "that(book, lend)\n" +
+		                       "_relmod(book, that)\n" +
+					"_rel(that, lend)\n" +
 		                       "_predadj(book, boring)\n");
 
 		rc &= test_sentence("They ate a special curry which was recommended by the restaurant’s owner.",
 		                       "_obj(eat, curry)\n" +
 		                       "_subj(eat, they)\n" +
 		                       "_obj(recommend, curry)\n" +
-		                       "by(recommend, owner)\n" +
+					"_advmod(recommend, by)\n" +
+		                       "_pobj(by, owner)\n" +
 		                       "_poss(owner, restaurant)\n" +
-		                       "which(curry, recommend)\n" +
-		                       "_amod(curry, special)\n");
+		                       "_rel(which, recommend)\n" +
+		                       "_amod(curry, special)\n" +
+					"_relmod(curry, which)\n");
 
 		rc &= test_sentence("The dog who Jack said chased me was black.",
 		                       "_obj(chase, me)\n" +
 		                       "_subj(chase, dog)\n" +
+					"_rep(say, chase)\n" +
+					"_rel(who, chase)\n" +
 		                       "_subj(say, Jack)\n" +
 		                       "_predadj(dog, black)\n" +
-		                       "who(dog, chase)\n");
+		                       "_relmod(dog, who)\n");
 
 		rc &= test_sentence("Jack, who hosted the party, is my cousin.",
 		                       "_obj(be, cousin)\n" +
@@ -1230,19 +1255,24 @@ public class TestRelEx
 		                       "_obj(stop, car)\n" +
 		                       "_subj(stop, Jack)\n" +
 		                       "_advmod(drive, fast)\n" +
-		                       "_predadj(car, drive)\n" +
-		                       "that(car, drive)\n" +
+					"_subj(drive, car)\n" +
+		                       "_relmod(car, that)\n" +
+					"_rel(that, drive)\n" +
 		                       "_nn(car, police)\n");
 
 		rc &= test_sentence("Just before the crossroads, the car was stopped by a traffic sign that stood on the street.",
 		                       "_obj(stop, car)\n" +
-		                       "by(stop, sign)\n" +
-		                       "_advmod(stop, just)\n" +
-		                       "on(stand, street)\n" +
-		                       "_subj(stand, sign)\n" +
-		                       "that(sign, stand)\n" +
+		                       "_pobj(by, sign)\n" +
+		                       "_advmod(before, just)\n" +
+					"_advmod(stand, on)\n" +
+		                       "_pobj(on, street)\n" +
+		                       "_advmod(stop, by)\n" +
+					"_subj(stand, sign)\n" +
+		                       "_relmod(sign, that)\n" +
+					"_rel(that, stand)\n" +
 		                       "_nn(sign, traffic)\n" +
-		                       "before(just, crossroads)\n");
+					"_advmod(stop, just)\n" +
+		                       "_pobj(before, crossroads)\n");
 
 		report(rc, "Extrapostion");
 		return rc;
@@ -1289,7 +1319,7 @@ public class TestRelEx
 		                     "_subj(tell, you)\n");
 
 		rc &= test_sentence ("What did you give to Mary?",
-					"_advmod(give, to\n)" +
+					"_advmod(give, to)\n" +
 					"_pobj(to, Mary)\n" +
 		                     "_obj(give, _$qVar)\n" +
 		                     "_subj(give, you)\n");
@@ -1303,11 +1333,13 @@ public class TestRelEx
 		rc &= test_sentence ("To whom did you sell the children?", 
 		                     "_pobj(to, _$qVar)\n" +
 		                     "_obj(sell, child)\n" +
+					"_advmod(sell, to)\n" +
 		                     "_subj(sell, you)\n");
 
 		rc &= test_sentence ("To what do we owe the pleasure?", 
 		                     "_pobj(to, _$qVar)\n" +
 		                     "_obj(owe, pleasure)\n" +
+					"_advmod(owe, to)\n" +
 					"_subj(owe, we)\n");
 
 		rc &= test_sentence ("Who did you sell the children to?",
@@ -1342,7 +1374,8 @@ public class TestRelEx
 
 		rc &= test_sentence ("Who's on first?",
 		                     "_pobj(on, first)\n" +
-		                     "_psubj(on, _$qVar)\n");
+		                     "_psubj(on, _$qVar)\n" +
+					"_advmod(be, on)\n");
 		
 		rc &= test_sentence ("Who farted?",
 		                     "_subj(fart, _$qVar)\n");
@@ -1392,6 +1425,7 @@ public class TestRelEx
 
 		rc &= test_sentence ("Must she be able to sing?",
 		                     "_to-do(able, sing)\n" +
+					"_modal(must, able)\n" +
 		                     "_predadj(she, able)\n");
 
 		rc &= test_sentence ("Does she want to sing?",
@@ -1402,14 +1436,14 @@ public class TestRelEx
 		                     "_subj(sleep, you)\n");
 
 		rc &= test_sentence ("Will you sleep?",
-		                     "_subj(sleep, you)\n");
+		                     "_subj(sleep, you)\n" +
+					"_modal(will, sleep)\n");
 		
 		rc &= test_sentence ("Did you sleep?",
 		                     "_subj(sleep, you)\n");
 
-		rc &= test_sentence ("Did you eat the leftover baba-pizza?",
+		rc &= test_sentence ("Did you eat the pizza?",
 					"_obj(eat, pizza)\n" +
-					"_amod(pizza, leftover)\n" +
 		                     "_subj(eat, you)\n");
 
 		rc &= test_sentence ("Did you give her the money?",
@@ -1444,20 +1478,24 @@ public class TestRelEx
 		                     "_subj(help, you)\n");
 
 		rc &= test_sentence ("She is nice to help with the project.", 
-		                     "with(help, project)\n" +
+		                     "_pobj(with, project)\n" +
+					"_advmod(help, with)\n" +
 		                     "_to-do(nice, help)\n" +
 		                     "_predadj(she, nice)\n");
 
 		rc &= test_sentence ("She must be able to sing.",
 		                     "_to-do(able, sing)\n" +
+					"_modal(must, able)\n" +
 		                     "_predadj(she, able)\n");
 
 		rc &= test_sentence ("She must need to sing?", 
 		                     "_to-do(need, sing)\n" +
+					"_modal(must, need)\n" +
 		                     "_subj(need, she)\n");
 
 		rc &= test_sentence ("She must want to sing?", 
 		                     "_to-do(want, sing)\n" +
+					"_modal(must, want)\n" +
 		                     "_subj(want, she)\n");
 
 		rc &= test_sentence ("She wants to sing.",
@@ -1479,6 +1517,7 @@ public class TestRelEx
 
 		rc &= test_sentence ("Where will she be happy?", 
 		                     "_%atLocation(happy, _$qVar)\n" +
+					"_modal(will, happy)\n" +
 		                     "_predadj(she, happy)\n");
 
 		rc &= test_sentence ("When did jazz die?",
@@ -1505,9 +1544,9 @@ public class TestRelEx
 		                     "_subj(live, you)\n");
 
 		rc &= test_sentence ("Why do you like terrible music?",
+					"_%because(like, _$qVar)/n" +
 		                     "_obj(like, music)\n" +
 		                     "_subj(like, you)\n" +
-					"_%because(like, _$qVar)/n" +
 					"_amod(music, terrible)\n");
 
 		rc &= test_sentence ("Why are you such a fool?",
@@ -1566,7 +1605,7 @@ public class TestRelEx
 		rc &= test_sentence ("The books were written by Charles Dickens.",
 		                     "_obj(write, book)\n" +
 					"_advmod(write, by)\n" +
-					"_pobj(by, Bob)\n");
+					"_pobj(by, Charles_Dickens)\n");
 
 		rc &= test_sentence ("The books are published.",
 		                     "_obj(publish, book)\n");
@@ -1585,7 +1624,8 @@ public class TestRelEx
 		                     "_subj(eat, Madison)\n" +
 		                     "conj_and(John, Madison)\n");
 
-		rc &= test_sentence ("Joan is poor  but  happy.", 
+		rc &= test_sentence ("Joan is poor but happy.",
+					"conj_but(poor, happy)\n" +
 		                     "_predadj(Joan, poor)\n" +
 		                     "_predadj(Joan, happy)\n");
 
@@ -1593,6 +1633,7 @@ public class TestRelEx
 				    "_rep(think, that)\n" +
 				    "_comp(that, fly)\n" +
 		                     "_subj(think, I)\n" +
+					"_modal(can, fly)\n" +
 		                     "_subj(fly, dog)\n");
 
 		rc &= test_sentence ("He is glad that she won.",
@@ -1603,9 +1644,9 @@ public class TestRelEx
 
 		rc &= test_sentence ("He ran so quickly that he flew.",
 				    "_comp(that, fly)\n" +
-		                     "_advmod(quickly, so)\n" +
+		                     "_advmod(quickly, so_that)\n" +
 		                     "_subj(fly, he)\n" +
-		                     "that(run, fly)\n" +
+		                     "_compmod(so_that, that)\n" +
 		                     "_advmod(run, quickly)\n" +
 		                     "_subj(run, he)\n");
 

--- a/src/java_test/relex/test/TestRelEx.java
+++ b/src/java_test/relex/test/TestRelEx.java
@@ -175,7 +175,7 @@ public class TestRelEx
 		                     "_predet(boy, all)\n");
 
 		rc &= test_sentence ("Joan thanked Susan for all the help she had given.",
-					"_prepadv(thank, for)\n" +
+					"_advmod(thank, for)\n" +
 					"_pobj(for, help)\n" +
 		                     "_subj(thank, Joan)\n" +
 		                     "_obj(thank, Susan)\n" +
@@ -191,13 +191,13 @@ public class TestRelEx
 	{
 		boolean rc = true;
 		rc &= test_sentence("I had breakfast at 8 am.",
-					"_prepadv(have, at)\n" +
+					"_advmod(have, at)\n" +
 				    "_pobj(at, am)\n" +
 				    "_obj(have, breakfast)\n"+
 				    "_subj(have, I)\n" +
 				    "_time(am, 8)\n");
 		rc &= test_sentence("I had supper before 6 pm.",
-				    "_prepadv(have, before)\n" +
+				    "_advmod(have, before)\n" +
 				    "_pobj(before, pm)\n" +
 				    "_obj(have, supper)\n" +
 				    "_subj(have, I)\n" +
@@ -1271,9 +1271,8 @@ public class TestRelEx
 		                     "_det(bullshit, that)\n");
 
 		rc &= test_sentence ("Who told that story to the police?", 
-					"_prepadv(tell, to)\n" +
+					"_advmod(tell, to)\n" +
 					"_pobj(to, police)\n" +
-		                     "to(tell, police)\n" +
 		                     "_obj(tell, story)\n" +
 		                     "_subj(tell, _$qVar)\n" +
 		                     "_det(story, that)\n");
@@ -1290,16 +1289,16 @@ public class TestRelEx
 		                     "_subj(tell, you)\n");
 
 		rc &= test_sentence ("What did you give to Mary?",
-					"_prepadv(give, to\n)" +
+					"_advmod(give, to\n)" +
 					"_pobj(to, Mary)\n" +
 		                     "_obj(give, _$qVar)\n" +
 		                     "_subj(give, you)\n");
 
 		rc &= test_sentence ("Whom did you feed to the lions?", 
-					"_prepadv(feed, to)\n" +
+					"_advmod(feed, to)\n" +
 					    "_obj(feed, _$qVar)\n" +
 					    "_subj(feed, you)\n" +
-					    "_pobj(to, lion)\n";
+					    "_pobj(to, lion)\n");
 
 		rc &= test_sentence ("To whom did you sell the children?", 
 		                     "_pobj(to, _$qVar)\n" +
@@ -1312,7 +1311,7 @@ public class TestRelEx
 					"_subj(owe, we)\n");
 
 		rc &= test_sentence ("Who did you sell the children to?",
-					"_prepadv(sell, to)\n" +
+					"_advmod(sell, to)\n" +
 					"_pobj(to, _$qVar)\n" +
 		                     "_obj(sell, child)\n" +
 		                     "_subj(sell, you)\n");
@@ -1370,7 +1369,7 @@ public class TestRelEx
 		rc &= test_sentence ("Is the book under the table?",
 				   "_pobj(under, table)\n" +
 				    "_prepadj(book, under)\n" +
-				    "_subj(_%copula, book)\n";
+				    "_subj(_%copula, book)\n");
 
 		rc &= test_sentence ("Does he seem mad?",
 		                     "_to-be(seem, mad)\n" +
@@ -1419,7 +1418,7 @@ public class TestRelEx
 		                     "_subj(give, you)\n");
 
 		rc &= test_sentence ("Did you give the money to her?",
-					"_prepadv(give, to)\n" +
+					"_advmod(give, to)\n" +
 					"_pobj(to, her)\n" +
 		                     "_obj(give, money)\n" +
 		                     "_subj(give, you)\n");
@@ -1566,7 +1565,7 @@ public class TestRelEx
 
 		rc &= test_sentence ("The books were written by Charles Dickens.",
 		                     "_obj(write, book)\n" +
-					"_prepadv(write, by)\n" +
+					"_advmod(write, by)\n" +
 					"_pobj(by, Bob)\n");
 
 		rc &= test_sentence ("The books are published.",
@@ -1622,9 +1621,10 @@ public class TestRelEx
 		                     "_subj(think, you)\n");
 
 		rc &= test_sentence ("To whom did you sell the children?",
-		                     "to(sell, _$qVar)\n" +
+		                     "_advmod(sell, to)\n" +
 		                     "_obj(sell, child)\n" +
-		                     "_subj(sell, you)\n");
+		                     "_subj(sell, you)\n" +
+					"_pobj(to, _$qVar)\n");
 
 		rc &= test_sentence ("Why did you give him the money?",
 		                     "_iobj(give, him)\n" +
@@ -1702,6 +1702,11 @@ public class TestRelEx
 				"_advmod(run_away, from)\n" +
 				"_amod(man, run_away)\n");
 
+		rc &= test_sentence ("Among the employees was a deranged killer.",
+				"_pobj(among, employee)\n" +
+				"_amod(killer, deranged)\n" +
+				"_predadj(killer, among)\n" +
+				"_subj(be, killer)\n");
 
 
 		report(rc, "Adverbials and Adjectivals");
@@ -1775,13 +1780,13 @@ public class TestRelEx
 	{
 		boolean rc = true;
 		rc &= test_sentence ("Who did you give the book to?",
-				"_prepadv(give, to)\n" +
+				"_advmod(give, to)\n" +
 				"_obj(give, book)\n" +
 				"_subj(give, you)\n" +
 				"_pobj(to, _$qVar)\n");
 
 		rc &= test_sentence ("The people on whom you rely are sick.",
-				"_prepadv(rely, on)\n" +
+				"_advmod(rely, on)\n" +
 				"_subj(rely, you)\n" +
 				"_pobj(on, people)\n" +
 				"_comp(on, rely)\n" +
@@ -1810,7 +1815,7 @@ public class TestRelEx
 		rc &= ts.test_equatives();
 		rc &= ts.test_extraposition();
 		rc &= ts.test_conjunctions();
-		rc &= ts.test_inquisitives();
+		rc &= ts.test_interrogatives();
 
 		if (rc) {
 			System.err.println("Tested " + ts.pass + " sentences, test passed OK");

--- a/src/java_test/relex/test/TestRelEx.java
+++ b/src/java_test/relex/test/TestRelEx.java
@@ -1651,16 +1651,16 @@ public class TestRelEx
 		return rc;
 	}
 
-	public boolean test_adverbials_and_adjectivals()
+	public boolean test_adverbials_adjectivals()
 	{
 		boolean rc = true;
 		rc &= test_sentence ("He ran like the wind.",
-					"_prepadv(run, like)\n" +
+					"_advmod(run, like)\n" +
 					"_subj(run, he)\n" +
 					"_pobj(like, wind)\n");
 
 		rc &= test_sentence ("He was boring to an insufferable degree.",
-					"_prepadv(boring, to)\n" +
+					"_advmod(boring, to)\n" +
 					"_amod(degree, insufferable)\n" +
 					"_pobj(to, degree)\n" +
 					"_predadj(he, boring)\n");
@@ -1671,7 +1671,7 @@ public class TestRelEx
 					"_obj(impress, himself)\n");
 
 		rc &= test_sentence ("On Tuesday, he slept late.",
-				"_prepadv(sleep, on)\n" +
+				"_advmod(sleep, on)\n" +
 				"_advmod(sleep, late)\n" +
 				"_subj(sleep, he)\n" +
 				"_pobj(on, Tuesday)\n");
@@ -1680,6 +1680,29 @@ public class TestRelEx
 				"_obj(confuse, him)\n" +
 				"_advmod(confuse, often)\n" +
 				"_subj(confuse, people)\n");
+
+		rc &= test_sentence ("The man in window is a spy.",
+				"_obj(be, spy)\n" +
+				"_subj(be, man)\n" +
+				"_pobj(in, window)\n" +
+				"_prepadj(man, in)\n");
+
+		rc &= test_sentence ("He wrote largely in his spare time.",
+				"_advmod(write, in)\n" +
+				"_subj(write, he)\n" +
+				"_amod(time, spare)\n" +
+				"_poss(time, him)\n" +
+				"_pobj(in, time)\n" +
+				"_advmod(in, largely)\n");
+
+		rc &= test_sentence ("The man running away from us is a thief.",
+				"_obj(be, thief)\n" +
+				"_subj(be, man)\n" +
+				"_pobj(from, us)\n" +
+				"_advmod(run_away, from)\n" +
+				"_amod(man, run_away)\n");
+
+
 
 		report(rc, "Adverbials and Adjectivals");
 		return rc;


### PR DESCRIPTION
I found out that quesitons like "How crazy are you?" were not getting any _predadj dependency so I added one.  Except now, since they were getting a _subj() dependency, the SV-rule is firing twice, once for the _subj() and once for the _predadj() so I should correct that, although the redundancy isn't generating any incorrect relations, just redundancy.