### PR TITLE
LG Disjunct output + RelEx server's --logic argument separation

### DIFF
--- a/opencog-server.sh
+++ b/opencog-server.sh
@@ -42,14 +42,14 @@ bin:\
 /usr/local/share/java/linkgrammar.jar:\
 "
 
+# Return with RelEx2Logic, Link Grammar, and Relex output on default port 4444.
+java $VM_OPTS $RELEX_OPTS $CLASSPATH relex.Server --link --relex --logic
+
 # This will return parsed text on the input socket.
 java $VM_OPTS $RELEX_OPTS $CLASSPATH relex.Server --relex
 
 # Return Link Grammar and Relex output.
 # java $VM_OPTS $RELEX_OPTS $CLASSPATH relex.Server --link --relex --verbose
-
-# Return with RelEx2Logic Link Grammar, and Relex output on default port 4444.
-# java $VM_OPTS $RELEX_OPTS $CLASSPATH relex.Server --logic
 
 # Like the above, but listens on a non-default port
 # java $VM_OPTS $RELEX_OPTS $CLASSPATH relex.Server --logic --port 4242

--- a/src/java/relex/Server.java
+++ b/src/java/relex/Server.java
@@ -134,12 +134,7 @@ public class Server
 		if (commandMap.get("--link") != null) link_on = true;
 		if (commandMap.get("--relex") != null) relex_on = true;
 		if (commandMap.get("--free-text") != null) free_text = true;
-		if (commandMap.get("--logic") != null)
-		{
-			logic_on = true;
-			relex_on = true;
-			link_on = true;
-		 }
+		if (commandMap.get("--logic") != null) logic_on = true;
 
 		if (commandMap.get("--verbose") != null)
 		{
@@ -159,7 +154,7 @@ public class Server
 		DocSplitter ds = DocSplitterFactory.create();
 		LogicView logicView = new LogicView();
 
-		if (!relex_on && !link_on)
+		if (!relex_on && !link_on && !logic_on)
 		{
 			// By default just export RelEx output.
 			relex_on = true;
@@ -179,7 +174,7 @@ public class Server
 			System.err.println("Info: RelEx output on.");
 			opencog.setShowRelex(relex_on);
 		}
-		else
+		if (!relex_on && !logic_on)
 		{
 			re.do_apply_algs = false;
 		}

--- a/src/java/relex/feature/FeatureForeach.java
+++ b/src/java/relex/feature/FeatureForeach.java
@@ -18,7 +18,7 @@ package relex.feature;
 
 /**
  * The FeatureForeach class provides a backwards-compatible interface to
- * RelationForeach class.  Its use is deprecated.
+ * RelationForeach class.
  */
 
 public class FeatureForeach extends RelationForeach
@@ -36,6 +36,20 @@ public class FeatureForeach extends RelationForeach
 	{
 		// skip the LEFT-WALL
 		root = root.get("NEXT");
+		while (root != null)
+		{
+			Boolean rc = cb.FNCallback(root);
+			if (rc) return rc;
+			root = root.get("NEXT");
+		}
+		return false;
+	}
+	
+	/**
+	 * Same as foreachWord but does not skip the LEFT-WALL.
+	 */
+	public static Boolean foreachAll(FeatureNode root, FeatureNodeCallback cb)
+	{
 		while (root != null)
 		{
 			Boolean rc = cb.FNCallback(root);


### PR DESCRIPTION
* Changed the `--logic` argument to be independent from `--relex` and `--link`.  Useful for people who just want to see the R2L output but not all the other stuff.  (Use `--link --relex --logic` for the old functionality)

* Output the used disjunct for each word.  I was going to put it in OpenCogSchemeRel.java as suggested but it seems better to be in OpenCogSchemeLink.java since this is LG stuff (so can turn on and off with the `--link` argument rather than `--relex`)

