### PR TITLE
Added test case for one failing conjunction

### DIFF
--- a/src/java_test/relex/test/TestRelEx.java
+++ b/src/java_test/relex/test/TestRelEx.java
@@ -1150,6 +1150,13 @@ public class TestRelEx
 		                     "_advmod(run, quietly)\n" +
 		                     "_subj(run, she)\n" +
 		                     "conj_and(quickly, quietly)\n");
+		// conjoined verbs same object
+		rc &= test_sentence ("He steals and eats the orange.",
+		                     "_obj(steal, orange)\n" +
+		                     "_obj(eat, orange)\n" +
+		                     "_subj(steal, he)\n" +
+		                     "_subj(eat, he)\n" +
+		                     "conj_and(steal, eat)\n");
 		// adjectival modifiers on conjoined subject
 		rc &= test_sentence ("The big truck and the little car collided.",
 		                     "_amod(car, little)\n" +


### PR DESCRIPTION
... this might be a unique case because it is possible for the object not be shared, like

`He flew and reached the sky.`

No idea if it is possible to make RelEx handle this correctly.  Feel free to close this if this is impossible.