### PR TITLE
Output the original LG connector used

### DIFF
--- a/src/java/relex/output/OpenCogSchemeLink.java
+++ b/src/java/relex/output/OpenCogSchemeLink.java
@@ -57,6 +57,7 @@ class OpenCogSchemeLink
 	private String printLinks()
 	{
 		LinkCB cb = new LinkCB();
+		cb.parseID = parse.getIDString();
 		cb.str = "";
 		LinkForeach.foreach(parse.getLeft(), cb);
 		return cb.str;
@@ -64,37 +65,50 @@ class OpenCogSchemeLink
 	
 	private class LinkCB implements FeatureNodeCallback
 	{
+		String parseID;
 		String str;
 		public Boolean FNCallback(FeatureNode fn)
 		{
+			String lab = fn.get("LAB").getValue();
+			String lab_inst = fn.get("LAB").getValue() + "@" + parseID;
+			String fl_inst = fn.get("F_L").get("uuid").getValue();
+			String fr_inst = fn.get("F_R").get("uuid").getValue();
+			
 			str +=
 				"(EvaluationLink (stv 1.0 1.0)\n" +
-				"   (LinkGrammarRelationshipNode \"" +
-				fn.get("LAB").getValue() + "\")\n" +
+				"   (LinkGrammarRelationshipNode \"" + lab + "\")\n" +
 				"   (ListLink\n" +
-				"      (LgWordConn\n" +
-				"         (WordInstanceNode \"";
-
-			FeatureNode fl = fn.get("F_L");
-			FeatureNode labl = fn.get("lab_L");
-			str += fl.get("uuid").getValue() + "\")\n" +
-				"         (LgConnector\n" +
-				"            (LgConnectorNode \"" + labl.getValue() + "\")\n" +
-				"            (LgConnDirNode \"+\")\n" +
-				"         )\n" +
-				"      )\n" +
-				"      (LgWordConn\n" +
-				"         (WordInstanceNode \"";
-
-			FeatureNode fr = fn.get("F_R");
-			FeatureNode labr = fn.get("lab_R");
-			str += fr.get("uuid").getValue() + "\")\n" +
-				"         (LgConnector\n" +
-				"            (LgConnectorNode \"" + labr.getValue() + "\")\n" +
-				"            (LgConnDirNode \"-\")\n" +
-				"         )\n" +
-				"      )\n" +
+				"      (WordInstanceNode \"" + fl_inst + "\")\n" +
+				"      (WordInstanceNode \"" + fr_inst + "\")\n" +
 				"   )\n)\n";
+
+			str +=
+				"(EvaluationLink (stv 1.0 1.0)\n" +
+				"   (LgLinkInstanceNode \"" + lab_inst + "\")\n" +
+				"   (ListLink\n" +
+				"      (WordInstanceNode \"" + fl_inst + "\")\n" +
+				"      (WordInstanceNode \"" + fr_inst + "\")\n" +
+				"   )\n)\n";
+
+			FeatureNode labl = fn.get("lab_L");
+			FeatureNode labr = fn.get("lab_R");
+			str +=
+				"(LgLinkInstanceLink \n" +
+				"   (LgLinkInstanceNode \"" + lab_inst + "\")\n" +
+				"   (LgConnector\n" +
+				"      (LgConnectorNode \"" + labl.getValue() + "\")\n" +
+				"      (LgConnDirNode \"+\")\n" +
+				"   )\n" +
+				"   (LgConnector\n" +
+				"      (LgConnectorNode \"" + labr.getValue() + "\")\n" +
+				"      (LgConnDirNode \"-\")\n" +
+				"   )\n)\n";
+
+			str +=
+				"(ReferenceLink\n" +
+				"   (LgLinkInstanceNode \"" + lab_inst + "\")\n" +
+				"   (LinkGrammarRelationshipNode \"" + lab + "\")\n" +
+				")\n";
 			return false;
 		}
 	};

--- a/src/java/relex/output/OpenCogSchemeLink.java
+++ b/src/java/relex/output/OpenCogSchemeLink.java
@@ -72,15 +72,28 @@ class OpenCogSchemeLink
 				"   (LinkGrammarRelationshipNode \"" +
 				fn.get("LAB").getValue() + "\")\n" +
 				"   (ListLink\n" +
-				"      (WordInstanceNode \"";
+				"      (LgWordConn\n" +
+				"         (WordInstanceNode \"";
 
 			FeatureNode fl = fn.get("F_L");
+			FeatureNode labl = fn.get("lab_L");
 			str += fl.get("uuid").getValue() + "\")\n" +
-				"      (WordInstanceNode \"";
-
+				"         (LgConnector\n" +
+				"            (LgConnectorNode \"" + labl.getValue() + "\")\n" +
+				"            (LgConnDirNode \"+\")\n" +
+				"         )\n" +
+				"      )\n" +
+				"      (LgWordConn\n" +
+				"         (WordInstanceNode \"";
 
 			FeatureNode fr = fn.get("F_R");
+			FeatureNode labr = fn.get("lab_R");
 			str += fr.get("uuid").getValue() + "\")\n" +
+				"         (LgConnector\n" +
+				"            (LgConnectorNode \"" + labr.getValue() + "\")\n" +
+				"            (LgConnDirNode \"-\")\n" +
+				"         )\n" +
+				"      )\n" +
 				"   )\n)\n";
 			return false;
 		}

--- a/src/java/relex/output/OpenCogSchemeLink.java
+++ b/src/java/relex/output/OpenCogSchemeLink.java
@@ -125,23 +125,27 @@ class OpenCogSchemeLink
 			FeatureNode attr = srcNode.get("DISJUNCT");
 			if (!attr.isValued())
 				return false;
-			
+
 			String value = attr.getValue();
-			
+
+			// handle bad sentences where a word can have no connections
+			if (value.length() == 0)
+				return false;
+
 			// split the value into different connectors
 			String[] connectors = value.split(" ");
 
 			str += "(LgWordCset \n";
 			str += "    (WordInstanceNode \"" + srcNode.get("uuid").getValue() + "\")\n";
 			str += "    (LgAnd \n";
-			
+
 			// connectors should already be sorted with - before +
 			for (String conn : connectors)
 			{
 				String name;
 				String direction;
 				Boolean multi;
-				
+
 				if (conn.charAt(0) == '@')
 				{
 					name = conn.substring(1, conn.length() - 1);
@@ -154,20 +158,20 @@ class OpenCogSchemeLink
 					direction = conn.substring(conn.length() - 1);
 					multi = false;
 				}
-				
+
 				str += "        (LgConnector \n";
 				str += "            (LgConnectorNode \"" + name + "\")\n";
 				str += "            (LgConnDirNode \"" + direction + "\")\n";
-				
+
 				if (multi)
 					str += "            (LgConnMultiNode \"@\")\n";
-				
+
 				str += "        )\n";
 			}
-			
+
 			str += "    )\n";
 			str += ")\n";
-			
+
 			return false;
 		}
 	};


### PR DESCRIPTION
Changed how the `LinkGrammarRelationshipNode` is structure.  Now it is

```
(EvaluationLink (stv 1.0 1.0)
   (LinkGrammarRelationshipNode "Ds**c")
   (ListLink
      (LgWordConn
         (WordInstanceNode "the@da65d87c-22b9-4af2-89f4-60042816c579")
         (LgConnector
            (LgConnectorNode "D")
            (LgConnDirNode "+")
         )
      )
      (LgWordConn
         (WordInstanceNode "man@1a6d58eb-e9c0-4c8e-af01-8d4304e3430c")
         (LgConnector
            (LgConnectorNode "Ds**c")
            (LgConnDirNode "-")
         )
      )
   )
)
```
with a new link type (to-be-added) `LgWordConn`.

Right now the `nlp/learn` code also uses `LinkGrammarRelationshipNode` extensively, so this change will break them...  not 100% sure whether this is a good idea or not...

Also, with this information it is not really necessary to have the original disjunct stored.  Currently it is
```
(LgWordCset 
    (WordInstanceNode "man@1a6d58eb-e9c0-4c8e-af01-8d4304e3430c")
    (LgAnd 
        (LgConnector 
            (LgConnectorNode "Ds**c")
            (LgConnDirNode "-")
        )
        (LgConnector 
            (LgConnectorNode "Os")
            (LgConnDirNode "-")
        )
    )
)
```
