### PR TITLE
Fix for bug #236

### DIFF
--- a/src/java/relex/output/OpenCogSchemeRel.java
+++ b/src/java/relex/output/OpenCogSchemeRel.java
@@ -187,20 +187,16 @@ class OpenCogSchemeRel
 		int word_index = 1;
 		while (fn != null)
 		{
-			FeatureNode refNode = fn.get("ref");
-			if (refNode != null)
-			{
-				String lemma = getstr(fn.get("str"));
+			String lemma = getstr(fn.get("str"));
 
-				// Remember the word-to guid map; we'll need it for
-				// printing relations, and printing frames,
-				String guid_word = fn.get("uuid").getValue();
+			// Remember the word-to guid map; we'll need it for
+			// printing relations, and printing frames,
+			String guid_word = fn.get("uuid").getValue();
 
-				// The word instance, and its associated lemma form
-				refs += "(LemmaLink (stv 1.0 1.0)\n";
-				refs += "   (WordInstanceNode \"" + guid_word + "\")\n";
-				refs += "   (WordNode \"" + lemma + "\"))\n";
-			}
+			// The word instance, and its associated lemma form
+			refs += "(LemmaLink (stv 1.0 1.0)\n";
+			refs += "   (WordInstanceNode \"" + guid_word + "\")\n";
+			refs += "   (WordNode \"" + lemma + "\"))\n";
 
 			fn = fn.get("NEXT");
 			word_index ++;


### PR DESCRIPTION
The "obvious" fix is to remove the check for the ref node. Its
not clear why that check was ever there. the "ref" node should
almost surely always be ther, since the algs files creat this for
almost all situations, so its kind of strange that no alg created
a ref for "going"  (test sentence: "Tom asks Roy how they are going
to get the gold") so maybe the algs are broken.

Whatever. This fix works, and its safe. (Should be safe!?)