### PR TITLE
Force to overwrite destination file

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -72,7 +72,8 @@
        <echo message="Building RelEx version ${REVISION}"/>
        <copy file="src/java/relex/Version.java.in"
              tofile="src/java/relex/Version.java"
-             overwrite="yes">
+             overwrite="yes"
+             force="yes">
            <filterset>
                <filter token="REVISION" value="${REVISION}"/>
            </filterset>


### PR DESCRIPTION
BUILD FAILED
~/hansonrobotics/opencog/relex/build.xml:76: Failed to copy ~/hansonrobotics/opencog/relex/src/java/relex/Version.java.in to ~/hansonrobotics/opencog/relex/src/java/relex/Version.java due to can't write to read-only destination file ~/hansonrobotics/opencog/relex/src/java/relex/Version.java
