### PR TITLE
Fix install LG script

### DIFF
--- a/install-scripts/install-ubuntu-dependencies.sh
+++ b/install-scripts/install-ubuntu-dependencies.sh
@@ -21,9 +21,10 @@ sudo apt-get -y install openjdk-7-jdk
 sudo apt-get -y install ant libcommons-logging-java libgetopt-java
 
 # Link Grammar
-wget -r --no-parent -nH --cut-dirs=2 http://www.abisource.com/downloads/link-grammar/current/
+wget -r --no-parent -nH --cut-dirs=3 http://www.abisource.com/downloads/link-grammar/current/
 tar -xvf link-grammar-5.*.tar.gz
-rm link-grammar-5.*.tar.gz
+rm link-grammar-5.*.tar.gz*
+rm index.html*
 cd link-grammar-5.*
 JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64  ./configure 
 make -j6


### PR DESCRIPTION
With cut-dirs=2 wget (v.1.15) downloads files into 'current' dir and script fails with:
```
Downloaded: 13 files, 3,5M in 1,9s (1,81 MB/s)
tar: link-grammar-5.*.tar.gz: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
rm: cannot remove ‘link-grammar-5.*.tar.gz’: No such file or directory
./install-ubuntu-dependencies.sh: line 28: cd: link-grammar-5.*: No such file or directory
./install-ubuntu-dependencies.sh: line 29: ./configure: No such file or directory
```