### PR TITLE
Feature/263 load relex resources

### DIFF
--- a/src/java/relex/algs/AlgorithmApplier.java
+++ b/src/java/relex/algs/AlgorithmApplier.java
@@ -16,18 +16,18 @@
 
 package relex.algs;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import relex.ParsedSentence;
+import relex.concurrent.RelexContext;
+
 import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import relex.ParsedSentence;
-import relex.concurrent.RelexContext;
+import static relex.utils.ResourceUtils.getResource;
 
 /**
  * AlgorithmApplier is responsible for loading SentenceAlgorithms from a
@@ -75,7 +75,7 @@ public class AlgorithmApplier
 	 */
 	public void read(String prop, String filename)
 	{
-		InputStream in = getAlgorithmsFile(prop, filename);
+		InputStream in = getResource(prop, filename, "data");
 		algs = new ArrayList<SentenceAlgorithm>();
 		BufferedReader br = new BufferedReader(new InputStreamReader(in));
 
@@ -113,61 +113,6 @@ public class AlgorithmApplier
 			throw new RuntimeException("Cannot initialize class: " + e);
 		} catch (IllegalAccessException e) {
 			throw new RuntimeException("Cannot access class: " + e);
-		}
-	}
-
-	/**
-	 * Determine the relex algorithms file will be used.
-	 *
-	 * First try to load the the file defined by the system property
-	 * relex.algpath. Then try to load the file as a resource in the
-	 * jar file.  Finally, tries the default location (equivalent to
-	 * -Drelex.algpath=./data/relex-semantic-algs.txt)
-	 *
-	 * @return
-	 */
-	public static InputStream getAlgorithmsFile(String prop, String filename)
-	{
-		try
-		{
-			InputStream in = null;
-			String algsFileName = System.getProperty(prop);
-			if (algsFileName != null)
-			{
-				in = new FileInputStream(algsFileName);
-				if (in != null)
-				{
-					logger.info("Info: Using relex algorithms file defined in " +
-								prop + ": " + algsFileName);
-					return in;
-				}
-			}
-
-			in = AlgorithmApplier.class.getResourceAsStream(
-				"/" + filename);
-			if (in != null)
-			{
-					logger.info(
-						"Info: Using relex algorithms file defined as a resource.");
-				return in;
-			}
-
-			String defaultRelexAlgsFile =
-				"./data/" + filename;
-			in = new FileInputStream(defaultRelexAlgsFile);
-			if (in != null)
-			{
-					logger.info(
-						"Info: Using default relex algorithms file: {}",
-						 defaultRelexAlgsFile);
-				return in;
-			}
-
-			throw new RuntimeException("Error reading algorithms file.");
-		}
-		catch (FileNotFoundException exception)
-		{
-			throw new RuntimeException(exception);
 		}
 	}
 }

--- a/src/java/relex/corpus/DocSplitterOpenNLP15Impl.java
+++ b/src/java/relex/corpus/DocSplitterOpenNLP15Impl.java
@@ -86,8 +86,7 @@ public class DocSplitterOpenNLP15Impl implements DocSplitter
 	{
 		if (detector == null)
 		{
-			if (englishModelFilename == null)
-				englishModelFilename = System.getProperty("EnglishModelFilename");
+			englishModelFilename = System.getProperty("EnglishModelFilename");
 			if (englishModelFilename == null || englishModelFilename.isEmpty())
 				englishModelFilename = DEFAULT_ENGLISH_FILEPATH;
 

--- a/src/java/relex/corpus/DocSplitterOpenNLP15Impl.java
+++ b/src/java/relex/corpus/DocSplitterOpenNLP15Impl.java
@@ -20,8 +20,8 @@ package relex.corpus;
 import opennlp.tools.sentdetect.SentenceModel;
 import opennlp.tools.sentdetect.SentenceDetectorME;
 import opennlp.tools.util.Span;
+import relex.utils.ResourceUtils;
 
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,8 +36,12 @@ import java.util.HashSet;
 public class DocSplitterOpenNLP15Impl implements DocSplitter
 {
 	private static final int DEBUG = 0;
+	private static final String DEFAULT_ENGLISH_DIR =
+	        "data/opennlp/models-1.5";
 	private static final String DEFAULT_ENGLISH_FILENAME =
-	        "data/opennlp/models-1.5/en-sent.bin";
+	        "en-sent.bin";
+	private static final String DEFAULT_ENGLISH_FILEPATH =
+			DEFAULT_ENGLISH_DIR + "/" + DEFAULT_ENGLISH_FILENAME;
 
 	private static HashSet<String> unacceptableSentenceEnds;
 
@@ -82,23 +86,18 @@ public class DocSplitterOpenNLP15Impl implements DocSplitter
 	{
 		if (detector == null)
 		{
-			try
-			{
-				if (englishModelFilename == null)
-					englishModelFilename = System.getProperty("EnglishModelFilename");
-				if (englishModelFilename == null || englishModelFilename.length() == 0)
-					englishModelFilename = DEFAULT_ENGLISH_FILENAME;
-
-			}
-			catch (Exception e)
-			{
-				// e.printStackTrace();
-				System.err.println(e.getMessage());
-			}
+			if (englishModelFilename == null)
+				englishModelFilename = System.getProperty("EnglishModelFilename");
+			if (englishModelFilename == null || englishModelFilename.isEmpty())
+				englishModelFilename = DEFAULT_ENGLISH_FILEPATH;
 
 			try
 			{
-				InputStream modelIn = new FileInputStream(englishModelFilename);
+				InputStream modelIn = ResourceUtils.getResource(
+						"EnglishModelFilename",
+						DEFAULT_ENGLISH_FILENAME,
+						DEFAULT_ENGLISH_DIR
+				);
 				SentenceModel model = new SentenceModel(modelIn);
 				modelIn.close();
 				detector = new SentenceDetectorME(model);

--- a/src/java/relex/morphy/MorphyFactory.java
+++ b/src/java/relex/morphy/MorphyFactory.java
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 
 import net.didion.jwnl.JWNL;
+import relex.utils.ResourceUtils;
 
 public class MorphyFactory
 {
@@ -65,7 +66,7 @@ public class MorphyFactory
 		try
 		{
 			JWNL.initialize(
-					getJWNLConfigFileStream(
+					ResourceUtils.getResource(
 							WORDNET_PROPERTY,
 							JWNL_FILE_PROPERTIES_XML,
 							JWNL_DIR_PROPERTIES_XML
@@ -85,48 +86,5 @@ public class MorphyFactory
 			System.err.println(estr);
 			return false;
 		}
-	}
-
-	/**
-	 * Determine the file that will be used.
-	 *
-	 * First try to load the the file in the directory defined by
-	 * the system property. Then try to load the file as a resource
-	 * in the jar file. Finally, tries the default location
-	 * (equivalent to -Dproperty=default)
-	 *
-	 * @param propertyName TODO
-	 *
-	 * @return
-	 * @throws FileNotFoundException
-	 */
-	private static InputStream getJWNLConfigFileStream (
-		            String propertyName,
-	               String file,
-	               String defaultDir)
-	throws FileNotFoundException
-	{
-			InputStream in = null;
-			String property = System.getProperty(propertyName);
-
-			if (property != null)
-			{
-				in = new FileInputStream(property);
-				if (in != null)
-				{
-					System.err.println("Info: Using file defined in " +
-						propertyName + ":" + property);
-					return in;
-				}
-			}
-
-			String defaultFile = defaultDir+"/"+file;
-			in = new FileInputStream(defaultFile);
-			if (in != null)
-			{
-				System.err.println("Info: Using default "+ defaultFile);
-				return in;
-			}
-			throw new RuntimeException("Error loading " + file + " file.");
 	}
 }

--- a/src/java/relex/utils/ResourceUtils.java
+++ b/src/java/relex/utils/ResourceUtils.java
@@ -1,0 +1,79 @@
+package relex.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+
+public class ResourceUtils
+{
+
+    private static final Logger logger = LoggerFactory.getLogger(ResourceUtils.class);
+
+    /**
+     * Finds the file location and returns an input stream to it.
+     * <p>
+     * First try to load the the file in the directory defined by
+     * the system property. Then try to load the file as a resource
+     * in the jar file. Finally, tries the default location
+     * (equivalent to -Dproperty="defaultDir/fileName")
+     *
+     * @param propertyName the property to read the file from
+     * @param fileName     file to read
+     * @param defaultDir   default directory where to look at the file
+     * @return input stream to the requested file
+     * @throws RuntimeException in case the file has not been found.
+     */
+
+    public static InputStream getResource(String propertyName,
+                                          String fileName,
+                                          String defaultDir)
+    {
+        try {
+            String filePath = System.getProperty(propertyName);
+            InputStream in = loadFromFile(filePath);
+            if (in != null) {
+                logger.info("Info: Using relex algorithms file defined in " +
+                        propertyName + ": " + filePath);
+                return in;
+            }
+
+            in = ResourceUtils.class.getResourceAsStream(
+                    "/" + fileName);
+            if (in != null) {
+                logger.info(
+                        "Info: Using relex algorithms file defined as a resource.");
+                return in;
+            }
+
+            File defaultRelexPath = new File(defaultDir, fileName);
+            in = loadFromFile(defaultRelexPath);
+            if (in != null) {
+                logger.info(
+                        "Info: Using default relex algorithms file: {}",
+                        defaultRelexPath);
+                return in;
+            }
+
+            throw new RuntimeException("Error loading " + fileName + " file.");
+        } catch (FileNotFoundException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+
+    private static InputStream loadFromFile(String file) throws FileNotFoundException
+    {
+        return file != null ? loadFromFile(new File(file)) : null;
+
+    }
+
+    private static InputStream loadFromFile(File filePath) throws FileNotFoundException
+    {
+        return filePath.exists() ? new FileInputStream(filePath) : null;
+
+    }
+}

--- a/src/java/relex/utils/ResourceUtils.java
+++ b/src/java/relex/utils/ResourceUtils.java
@@ -36,8 +36,8 @@ public class ResourceUtils
             String filePath = System.getProperty(propertyName);
             InputStream in = loadFromFile(filePath);
             if (in != null) {
-                logger.info("Info: Using relex algorithms file defined in " +
-                        propertyName + ": " + filePath);
+                logger.info("Loading resource from file name: {}," +
+                        " defined by Java property: {}", filePath, propertyName);
                 return in;
             }
 


### PR DESCRIPTION
- Unify resource loading by using ResourceUtils.getResource(...) method
- Resource are loaded in the order: check
1) system property 
2) jar
3) default dir

file_properties.xml and en-sent.bin are now loaded from jar file.
I have not found usage of the EnglishSD.bin.gz file. It seems that it can be loaded from outside relex  module.

There are some questions.
May be the order of loading resource should be: check the system property first, then the default dir and the jar at the last?

DocSplitterOpenNLP15Impl contains private variable englishModelFilename and two public methods setEnglishModelFilename(...)/setEnglishModelFilename().
It seems that the usage of the get/set methods are useless because the englishModelFilename field is only used during object construction and never after it.
It seems it has  sense to remove setEnglishModelFilename(...)/setEnglishModelFilename() methods if they are not used by other modules (in other case there will be binary incompatibility).