### PR TITLE
Copy relex.jar dependencies into ./target/lib folder.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,24 @@
 		<sourceDirectory>${basedir}/src/java</sourceDirectory>
 		<testSourceDirectory>${basedir}/src/java_test</testSourceDirectory>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>copy-dependencies</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>copy-dependencies</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>
+								${project.build.directory}/lib
+							</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<!-- mvn -DskipTests package appassembler:assemble assembly:single -->
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Work on https://github.com/opencog/relex/issues/267. Use maven-dependencies-plugin to copy all of relex.jar dependencies to ./target/lib.