### PR TITLE
workaround surefire crash in debian/ubuntu

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,15 @@
 					</execution>
 				</executions>
 			</plugin>
+			<!-- workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925 - surefire crash during build -->
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <version>2.22.1</version>
+                            <configuration>
+                                <useSystemClassLoader>false</useSystemClassLoader>
+                            </configuration>
+                        </plugin>
 			<!-- mvn -DskipTests package appassembler:assemble assembly:single -->
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Build fails due to bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925
Using workaround posted in the bug report. Tested on ubuntu 18.04

```
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.659 s
[INFO] Finished at: 2018-11-02T10:19:25Z
[INFO] Final Memory: 11M/60M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test (default-test) on project relex: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test failed: The forked VM terminated without saying properly goodbye. VM crash or System.exit called ? -> [Help 1]
```