### PR TITLE
Remove dependency on word-sense ranking.

### DIFF
--- a/src/java/relex/RelationExtractor.java
+++ b/src/java/relex/RelationExtractor.java
@@ -155,7 +155,6 @@ public class RelationExtractor
 		if (do_apply_algs)
 		{
 			parser.getConfig().setStoreConstituentString(true);
-			parser.getConfig().setStoreSense(true);
 		}
 
 		setMaxParses(DEFAULT_MAX_PARSES);


### PR DESCRIPTION
This has not been suported for nearly a decade, and was removed
from link-grammar in version 4.7.0 -- Need to remove it in relex, too.
Fixes issue #283